### PR TITLE
Remove bootstrap maintainers repo access and add tech leads repo access

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -33,11 +33,7 @@ collaborators:
   - username: mkorbi
     permission: admin
 
-  # maintainers: BOOTSTRAPPING MAINTAINERS, the TAG is currently in the formation phase and has not yet documented governance or appointed maintainers.
+  # CNCF TAG Environmental Sustainability Tech Leads
   # Alphabetically
-  - username: cdeliaRH
-    permission: maintain
-  - username: nikimanoledaki
-    permission: maintain
-  - username: scottrigby
+  - username: caradelia
     permission: maintain


### PR DESCRIPTION
This updates just the `.github/settings.yml` file. 

* Remove bootstrap maintainers since they are not defined as an entity in the governance
* Add tech lead since they are defined in the governance and @caradelia has been elected
