### PR TITLE
Add a note about sustainability.cncf.io to the README

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -8,7 +8,7 @@ repository:
   description: 🌳🌍♻️ TAG Environmental Sustainability 
 
   # A URL with more information about the repository
-  homepage: https://cncf.io/projects
+  homepage: https://sustainability.cncf.io/
   
   # Collaborators: give specific users access to this repository.
   # Note: changing this file will update the users visible in Github UI 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ The [TAG Environmental Sustainability Charter](charter.md) further outlines the 
 Within our [glossary](./glossary/glossary.md) you can find common wording, abbreviations and definitions we might use frequently. 
 In case you are missing something or is unclear, your contribution is more than welcome!
 
+## Website
+
+In addition to what you can find in this repository, the TAG Environmental Sustainability maintains the website [sustainability.cncf.io](https://sustainability.cncf.io/) to more easily present information about TAG.
+
 ## Contact
 
 * The working group meets every 1st and 3rd Wednesday at 5pm CEST/GMT+2 (8am Pacific) on [Zoom](https://zoom.us/my/cncftagenvsustainability)


### PR DESCRIPTION
Add a reference of the new TAG Environmental Sustainability website to the README

ref: #53 

cc @caradelia