### PR TITLE
Cleanup website page structure

### DIFF
--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -1,6 +1,6 @@
 ---
 title: TAG Environmental Sustainability
-toc_hide: false
+toc_hide: true
 ---
 
 <div class="row mt-5 mb-3">

--- a/website/content/about/SustainabilityUseCasesAndLandscape2023.md
+++ b/website/content/about/SustainabilityUseCasesAndLandscape2023.md
@@ -1,7 +1,10 @@
 ---
-title: Current Sustainability Efforts and Challenges Within the Cloud Native Landscape v0.1
+title: Cloud Native Sustainability Landscape
 description: This captures the known and ongoing sustainability efforts within the cloud native landscape as well as identifies challenge areas.
+slug: landscape
 ---
+
+*This document is in version 0.1 and contains gaps which will be addressed in the upcoming versions. Contributions are very welcome!*
 
 Cloud computing has revolutionized the way we store and process data, enabling organizations to be more agile, efficient, and scalable.
 However, as companies transform their business models to meet sustainability requirements, concerns about environmental sustainability in cloud computing have also emerged.

--- a/website/content/about/_index.md
+++ b/website/content/about/_index.md
@@ -2,8 +2,9 @@
 title: About TAG Environmental Sustainability
 linkTitle: About
 toc_hide: true
+list_pages: true
 menu:
   main:
     weight: 20
-description: Projects and initatives maintained by TAG Environmental Sustainability
+description: Projects and initiatives maintained by TAG Environmental Sustainability
 ---

--- a/website/content/events/2023-oss-na.md
+++ b/website/content/events/2023-oss-na.md
@@ -1,6 +1,7 @@
 ---
 title: Open Source Summit NA 2023
 description: TAG Environmental Sustainability presence at the Linux Foundation’s flagship conference in Vancouver, British Columbia from 10-12 May, 2023.
+weight: 2
 ---
 
 Level up your open source knowledge with access to 15 micro-conferences, including SustainabilityCOn, and 300+ sessions. Join the ultimate gathering of open source innovators to learn, network and collaborate in Vancouver, British Columbia from 10-12 May, 2023.


### PR DESCRIPTION
updated some small details how the website is structured

* Event Kubecon was listed before the event OSS NA. Added a page `weight` to the document
* About us page didnt listed the lanscape document properly
* Landscape document had a weird url path added `slug` so its stable over versions. Added a note to the top of the document pointing out the version (v0.1)