### PR TITLE
#101 Enable mermaid integration

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -111,6 +111,10 @@ prism_syntax_highlighting = false
   branch = "main"
   subdir = "website"
 
+# Configure mermaid (charting) integration
+[params.mermaid]
+enable = true
+
 # User interface configuration
 [params.ui]
 #  Set to true to disable breadcrumb navigation.

--- a/website/content/about/SustainabilityUseCasesAndLandscape2023.md
+++ b/website/content/about/SustainabilityUseCasesAndLandscape2023.md
@@ -207,9 +207,6 @@ For instance, Federated Learning spreads model training to devices that do not r
 The diagram below illustrates the dimensions of the sustainable cloud computing landscape, which are described in detail in the following sections.
 
 ```mermaid
----
-title: Overview of the Sustainable Cloud Computing Landscape
----
 %%{init: {'theme':'neutral'}}%%
 flowchart TB
     root{{Sustainable Cloud Computing Landscape}} -.- dc[Data centers] & methodologies[Methodologies]
@@ -258,9 +255,6 @@ OpenTelemetry integrates with popular libraries and frameworks such as Spring, A
 The diagram below illustrates the infrastructure dimension of the sustainable cloud computing landscape.
 
 ```mermaid
----
-title: The Observability Domain of the Sustainable Cloud Computing Landscape
----
 %%{init: {'theme':'neutral'}}%%
 flowchart TB
     root{{Observability - Sustainable Cloud Computing Landscape}} -.- obs[Observability Tooling]
@@ -327,9 +321,6 @@ We display these visualizations in a dashboard for developers, sustainability le
 The diagram below illustrates the infrastructure dimension of the sustainable cloud computing landscape.
 
 ```mermaid
----
-title: The Infrastructure Domain of the Sustainable Cloud Computing Landscape
----
 %%{init: {'theme':'neutral'}}%%
 flowchart TB
     root{{Infrastructure - Sustainable Cloud Computing Landscape}} -.- scheduling[Scheduling] & scaling[Scaling] & tuning[Resource Tuning]


### PR DESCRIPTION
Remove titles from mermaid charts since they're not supported in mermaid version 8.8.1

Now the charts are rendered as intended. For example:
![image](https://github.com/cncf/tag-env-sustainability/assets/57600104/aaed42d8-5833-4f08-b1a5-6eff5628ee47)
