### PR TITLE
Add meeting host playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ In addition to what you can find in this repository, the TAG Environmental Susta
 * Meeting notes & agenda can be found [here](https://docs.google.com/document/d/1TkmMyXJABC66NfYmivnh7z8Y_vpq9f9foaOuDVQS_Lo/edit#)
 * Public discussion runs on our [mailing list](https://lists.cncf.io/g/cncf-tag-env-sustainability/) via mailto:cncf-tag-env-sustainability@lists.cncf.io
 * Reach us at [#tag-environmental-sustainability](https://cloud-native.slack.com/archives/C03F270PDU6) slack channel on slack.cncf.io
+* Social Media: 
+  * Twitter: [@CNCFEnvTAG](https://twitter.com/CNCFEnvTAG)
 
 ### TAG Environmental Sustainability Co-Chairs
 

--- a/governance/meeting-host-playbook.md
+++ b/governance/meeting-host-playbook.md
@@ -5,7 +5,8 @@ Meetings are held to coordinate and discuss TAG ENV activities. The TAG ENV lead
 ## Requirements to host the meeting
 
 * Install Zoom and check your settings (especially audio and video).
-* Get access to the [CNCF TAG YouTube Channel](https://www.youtube.com/@CNCFEnvTAG) to start the livestream.
+* Get access to the CNCF TAG ENV Zoom account or receive the `hostkey` to start and stop recordings.
+* Get access to the [CNCF TAG YouTube Channel](https://www.youtube.com/@CNCFEnvTAG) to set the meeting recordings public.
 
 ## Pre-Meeting
 * Add a new blank agenda entry to the meeting notes by copying the template and editing the details accordingly.
@@ -27,19 +28,18 @@ If anyone has anything they’d like to discuss, please add to it to the agenda,
 ### Preparation
 
 * Slack reminder (thread) *"The meeting start now!"*
-* [Join](https://zoom.us/my/cncftagenvsustainability) the meeting
+* [Join](https://zoom.us/my/cncftagenvsustainability) the meeting with the CNCF TAG ENV Zoom account or claim host by entering the `hostkey`
 * Turn on your camera
 * Say hello to everyone 
   * *"Hello all, let's wait a few minutes for everyone to join"*
 * Ask for a note taker
 * Post the meeting notes to the meeting chat
   * *"I posted the meeting notes link to chat, please add yourself to the attendees list, thank you!"*
-* Prepare the YouTube livestream
 * Open meeting notes and share screen
 * Wait until 5 minutes have passed. Talk to people during this time so that the session does not get stalled.
   * *"Since it is now 3 minutes past, we will get started"*
   * *"If you rather not get recorded, you can now turn off your video"*
-* Start the YouTube livestream
+* Start the Zoom recording
 
 ### Intro
 
@@ -66,7 +66,7 @@ If anyone has anything they’d like to discuss, please add to it to the agenda,
 
 ### End of the Meeting
 * *"Is there anything else you like to discuss?"*
-* End the Livestream
+* End the Recording
 * Off record discussions *"I stopped the recording, is there anything you like to discuss off record?"* wait a few seconds
 * Thank all for joining the meeting *"Thank you all again for joining the meeting, see you in the next one!"*
 
@@ -85,3 +85,15 @@ Thanks all for attending the meeting!
 
 Talk to you all latest at the next TAG ENV meeting on the [<data>](https://tockify.com/cncf.public.events/monthly?search=TAG%20Environmental%20Sustainability).
 ```
+
+Go to the [CNCF TAG YouTube Channel Studio Page](https://studio.youtube.com/channel/UCMOopJuyyIWB8vXGct1ffNw/videos/upload?filter=%5B%5D&sort=%7B%22columnType%22%3A%22date%22%2C%22sortOrder%22%3A%22DESCENDING%22%7D) and look up your recent meeting. This may take up to 1h to show up.
+
+1. Click on "Details" to update recording settings (pencil icon)
+2. Update the following parts
+   1. Remove the timestamp off the meeting title `CNCF TAG ENV Meeting 2023-06-14T14:56:38Z` -> `CNCF TAG ENV Meeting 2023-06-14`
+   2. Upload the generic thumbnail ([link](https://drive.google.com/drive/folders/153zPgRVBhR4fZVPLMgNQC0obCPwqonRa?ths=true))
+   3. Add the meeting to the community meeting playlist
+   4. Select it is made of kids
+   5. Update the visibility to public
+3. Publish the video to YouTube
+4. Drop a link to the YouTube recording in Slack

--- a/governance/meeting-host-playbook.md
+++ b/governance/meeting-host-playbook.md
@@ -1,0 +1,87 @@
+# TAG Environmental Sustainability Meeting Host Playbook
+
+Meetings are held to coordinate and discuss TAG ENV activities. The TAG ENV leads host these meetings. The following playbook can be used for reference to structure the meeting, you don't need to stick step by step (word by word), it should give guidance how a meeting usually is structured.
+
+## Requirements to host the meeting
+
+* Install Zoom and check your settings (especially audio and video).
+* Get access to the [CNCF TAG YouTube Channel](https://www.youtube.com/@CNCFEnvTAG) to start the livestream.
+
+## Pre-Meeting
+* Add a new blank agenda entry to the meeting notes by copying the template and editing the details accordingly.
+* Announce a day in advance in Slack to add agenda items to meeting notes.
+* Announce the meeting about an hour before in the `#tag-env-sustainability` Slack channel.
+* Announce the meeting over [social media](https://github.com/cncf/tag-env-sustainability#contact) a day before. If there is a special presentation / occasion, you may want to announce it a total of two times a week in advance.
+
+```
+Hi folks! The CNCF TAG ENV bi-weekly meeting takes place 1 hour from now
+Links:
+* Agenda & Minutes: https://bit.ly/cncf-tag-env-meeting-notes
+* Zoom Link: https://zoom.us/my/cncftagenvsustainability, passcode `77777`
+
+If anyone has anything they’d like to discuss, please add to it to the agenda, thanks!
+```
+
+## During the Meeting
+
+### Preparation
+
+* Slack reminder (thread) *"The meeting start now!"*
+* [Join](https://zoom.us/my/cncftagenvsustainability) the meeting
+* Turn on your camera
+* Say hello to everyone 
+  * *"Hello all, let's wait a few minutes for everyone to join"*
+* Ask for a note taker
+* Post the meeting notes to the meeting chat
+  * *"I posted the meeting notes link to chat, please add yourself to the attendees list, thank you!"*
+* Prepare the YouTube livestream
+* Open meeting notes and share screen
+* Wait until 5 minutes have passed. Talk to people during this time so that the session does not get stalled.
+  * *"Since it is now 3 minutes past, we will get started"*
+  * *"If you rather not get recorded, you can now turn off your video"*
+* Start the YouTube livestream
+
+### Intro
+
+* Welcome everyone
+  * *"Hello everyone, my name is 'Alice' and I will be the host for this CNCF TAG Environmental Sustainability meeting"*
+* Call out the date for the record
+  *  *"Today is 'Monday' 'May' the '4th'"*
+* Mention the CoC 
+  * *"Please be aware that this is a CNCF community meeting which falls under the CNCF code of conduct, which can be summarized to be excellent to each other, thank you all!"*
+* Recording warning 
+  * *"This meeting is recorded and will be publicly posted to YouTube so please be mindful what you say is being recorded."*
+
+### Agenda
+
+* Introductions
+  * "I am pleased that you are all here. Before we continue with the recurring topics of the meeting, I would like to open the floor to anyone who would like to introduce themselves to the group and perhaps describe why they are interested in the TAG."
+* WG updates
+  * *"Lets start with the working group updates"*
+  * Call the person giving the update and wait for the update. Ask if there are any comments or questions for the team. 
+  * If no one from the WG gives the update, then you can review the last update given in a previous meeting, read it aloud, and then move to the next WG.
+* Open discussion items: 
+  * If something is on the list, you can read it out loud and wait for the person to respond.
+  * If there is nothing on the open discussion list, you can say something like: *"There is nothing in the open discussion section in the meeting notes. Is there anything to discuss before we get into the team updates?"* wait a few seconds - *"Okay, let's move on"*
+
+### End of the Meeting
+* *"Is there anything else you like to discuss?"*
+* End the Livestream
+* Off record discussions *"I stopped the recording, is there anything you like to discuss off record?"* wait a few seconds
+* Thank all for joining the meeting *"Thank you all again for joining the meeting, see you in the next one!"*
+
+## Post-Meeting
+
+* Reply to the Slack
+  * Link the YT recording
+  * Summarize any outstanding items or items you would like to highlight in the session
+
+```
+Thanks all for attending the meeting!
+
+* Recording:
+
+<list of outstanding discussion items>
+
+Talk to you all latest at the next TAG ENV meeting on the [<data>](https://tockify.com/cncf.public.events/monthly?search=TAG%20Environmental%20Sustainability).
+```


### PR DESCRIPTION
In the past our meetings where a bit unstructured and we missed sending out announcements, calling out the CoC ...

This PR adds a playbook which describes the outline of each TAG ENV meeting. 