### PR TITLE
Improve process for presenting in regular meetings

### DIFF
--- a/.github/ISSUE_TEMPLATE/presentation.md
+++ b/.github/ISSUE_TEMPLATE/presentation.md
@@ -1,6 +1,6 @@
 ---
 name: Presentation
-about: Have something you want to share with the group? Or someone you would like to invite to speak? Propose a presentation for the TAG-Security weekly meetings.
+about: Have something you want to share with the group? Or someone you would like to invite to speak? Propose a presentation for the TAG Environmental Sustainability regular meetings.
 title: "[Presentation] some descriptive title"
 labels: "presentation, triage-required"
 assignees: ''
@@ -28,7 +28,8 @@ assignees: ''
 ...
 
 ### Time
-<!-- How long will the presentation take? (estimate) -->
+<!-- How long will the presentation take? Please aim for 10 minutes or limit the presentation to 15 minutes to leave
+enough time for discussion and other agenda items. (estimate) -->
 
 ...
 

--- a/.github/ISSUE_TEMPLATE/presentation.md
+++ b/.github/ISSUE_TEMPLATE/presentation.md
@@ -37,3 +37,13 @@ enough time for discussion and other agenda items. (estimate) -->
 <!-- What is the availability times of the speakers to present the topic? Meeting times are listed on the landing page. -->
 
 ...
+
+### Steps
+1. [ ] First, contact one of [TAG ENV
+   Co-Chairs](https://github.com/cncf/tag-env-sustainability#tag-environmental-sustainability-co-chairs) or [TLs](https://github.com/cncf/tag-env-sustainability#tag-environmental-sustainability-tech-leads) to confirm your presentation. You can tag them in this GitHub issue or contact them on the CNCF Slack.
+2. [ ] Then, add the topic to the Agenda of the upcoming regular meeting in the
+   [meeting
+   notes](https://docs.google.com/document/d/1TkmMyXJABC66NfYmivnh7z8Y_vpq9f9foaOuDVQS_Lo/edit).
+   Format: _[NAME] Presentation: "<title of your presentation>"_ <link to this
+   issue>
+3. [ ] Post a message in the CNCF Slack channel `#tag-env-sustainability channel` to inform other TAG ENV contributors!


### PR DESCRIPTION
- Removing a reference to TAG Security 
- Adding guidelines for presentation duration
- Add steps for presenters to how to get approval, add the presentation to the agenda, and share the presentation in Slack.