### PR TITLE
Add cloud native sustainability website page

### DIFF
--- a/website/content/about/CloudNativeSustainabilityWeek.md
+++ b/website/content/about/CloudNativeSustainabilityWeek.md
@@ -1,0 +1,80 @@
+---
+title: CNCF Cloud Native Sustainability Week
+description: Cloud Native Sustainability Week is an event to organize meetings in CNCF community groups around the theme of Cloud Native Sustainability during the second week of October 2023.
+slug: cloud-native-sustainability-week
+---
+
+The CNCF Global Week of Cloud Native Sustainability is an event organized by the [Cloud Native Computing Foundation (CNCF)](http://cncf.io) community to address the emerging topic of environmental sustainability in the cloud native industry and open-source space. The event aims to engage with the community and industry, understand the current landscape, and promote collaboration and knowledge sharing.
+
+During the **second week of October 2023 (W41)**, the [broader Cloud Native community](https://community.cncf.io/chapters/) will organize meetups in their cities with a focus on cloud native sustainability. These meetups can be organized by anyone interested in supporting the effort. Additionally, the [CNCF Environmental Sustainability Technical Advisory Group (TAG ENV)](http://github.com/cncf/tag-env-sustainability), will host a virtual meetup using the [bevy](http://bevy.com) platform.
+
+1. **Local in-person events**: Meetups organized worldwide during the second week of October 2023 by [CNCF community groups](https://community.cncf.io/chapters/) about cloud native sustainability.
+2. **Virtual Event**: A virtual meetup organized by the CNCF TAG ENV.
+
+Please take a look at this [document](https://docs.google.com/document/d/1s28lqqc3IBAMw4T7n13zfyAuUEEc3I4_xhPxCLA4_dk/edit?usp=sharing) for a more detailed overview.
+
+## Meetup Locations
+
+*Note that this list is changing, we will publish a complete overview a few weeks for the event! Take a look at this [document](https://docs.google.com/document/d/1s28lqqc3IBAMw4T7n13zfyAuUEEc3I4_xhPxCLA4_dk/edit#heading=h.19phjl5j6fdw) to check the latest status, and persons to contact.*
+
+| **Nr** | **Name** | **Location** | **Date** | **Event Link** |
+|---|---|---|---|---|
+| 1 | Adam Gardner, Prateek Nayak | Australia, Sydney | *tbd* | *tbd* |
+| 2 | Alessandro Vozza | Netherlands, Amsterdam | *tbd* | *tbd* |
+| 3 | Angel Ramirez | Latin America | *tbd* | *tbd* |
+| 4 | Ayrat Khayrettdinov | Canada, Toronto | *tbd* | *tbd* |
+| 5 | Divya Mohan | India | *tbd* | *tbd* |
+| 6 | Johann Gyger | Switzerland, Bern | *tbd* | *tbd* |
+| 7 | Josh Gavant | USA, Chicago | *tbd* | *tbd* |
+| 8 | Kasper Nissen | Denmark, Aarhus | *tbd* | *tbd* |
+| 9 | Kunal Kushwaha | England, London | *tbd* | *tbd* |
+| 10 | Nancy Chauhan | India, Bangalore | *tbd* | *tbd* |
+| 11 | Rynn Mancuso | USA, Oakland | *tbd* | *tbd* |
+| 12 | Seokho Son, Hoon Jo | Korea, Seoul | *tbd* | *tbd* |
+| 13 | Sergio Mendez | Guatemala | *tbd* | *tbd* |
+| 14 | Yiming Peng | USA, Seattle | *tbd* | *tbd* |
+| 15 | Phil Huang | Taiwan, Taipei | *tbd* | *tbd* |
+| 16 | Carol Valencia | Brasil, São Paulo | *tbd* | *tbd* |
+| 17 | Niki Manoledaki | Spain, Barcelona | *tbd* | *tbd* |
+| 18 | Rodolfo Martínez Vega | Mexico, Guadalajara | *tbd* | *tbd* |
+| 19 | Kristina Devochko | Norway, Oslo | *tbd* | *tbd* |
+| 20 | Vinothini B, Manikandan, Vijayabharathi  | India, Chennai | *tbd* | *tbd* |
+| 21 | Stéphane Este-Gracias | Luxembourg, Luxembourg | *tbd* | *tbd* |
+| 22 | Adam Roe | Germany, Berlin | *tbd* | *tbd* |
+| 23 | Aydin Mir Mohammadi | Germany, Karlsruhe | *tbd* | *tbd* |
+| 24 | Leonard Pahlke | Germany, Hamburg | *tbd* | *tbd* |
+| 25 | Michel Murabito | Italy, Milan | *tbd* | *tbd* |
+
+## Event Goals
+
+1. **Understand the current [landscape](https://tag-env-sustainability.cncf.io/about/landscape/)**: Engaging with the community and industry to better understand the [landscape](https://tag-env-sustainability.cncf.io/about/landscape/) of cloud native environmental sustainability.
+2. **Identify Knowledge Gaps**: Identifying areas of knowledge gaps and further exploration in cloud native environmental sustainability.
+3. **Foster project collaboration**: Facilitating collaboration among participants on ongoing projects and tools related to cloud native sustainability.
+4. **Raise awareness**: Increasing awareness and knowledge about cloud native environmental sustainability.
+5. **Promote TAG ENV and CNCF**: Promoting the #tag-environmental-sustainability and raising awareness about the CNCF in general.
+6. **Survey**: distributing a survey to gather information on end user adoption of cloud native sustainability.
+7. **Badges**: providing badges from credly for organizers and potentially speakers.
+
+This [document](https://docs.google.com/document/d/1s28lqqc3IBAMw4T7n13zfyAuUEEc3I4_xhPxCLA4_dk/edit?usp=sharing) describes the goals in more detail and the plan how we can achieve them.
+
+## Contact and Resources
+
+Please reach out to us via the [CNCF Slack workspace](https://slack.cncf.io/) in the channel [tag-env-sustainability](https://cloud-native.slack.com/archives/C03F270PDU6), if you have any comments or questions. All resources are publicly accessible.
+If you are a meetup organizer, we have a [tracking issue](https://github.com/cncf/tag-env-sustainability/issues/134) to collect input and questions.
+
+* **General Tracking Issue**: https://github.com/cncf/tag-env-sustainability/issues/95
+* **General Meetup Organizer Guide**: https://docs.google.com/document/d/1s28lqqc3IBAMw4T7n13zfyAuUEEc3I4_xhPxCLA4_dk/edit?usp=sharing 
+* **Milestone to track the event organization tasks**: https://github.com/cncf/tag-env-sustainability/milestone/3
+* **Google Drive folder**: https://drive.google.com/drive/folders/1pdBQTxlpvDr0QFIuIpjfERau1IQNfdaX?ths=true 
+
+## Acknowledgements ✨
+
+The event is organized by volunteers in their spare time. Its truly a community effort without that this would not be possible. Thanks everyone for helping!
+
+Special thanks to Nancy Chauhan, Adriana Villela, Kristina Devochko, Niki Manoledaki, Mercy Bamiduro, Mehmet, Rodolfo Martínez Vega and Leonard Pahlke to help organise the event.
+
+Special thanks to all the local meetup organizers.
+
+Special thanks to Katie Gamanji, Ricardo Rocha, Wojtek Cichoń, Nikhita Raghunath, Tom Kerkhove, Alena Prokharchyk, Abdel Sghiouar, Huamin Chen, Nate W. and Emily Fox for facilitating, sharing their thoughts and reaching out to people that might be interested organizing a meetup.
+
+Special thanks to Katie Greenly and the entire CNCF team for their support.

--- a/website/content/cloud-native-sustainability-week/_index.md
+++ b/website/content/cloud-native-sustainability-week/_index.md
@@ -6,7 +6,7 @@ exclude_search: true
 menu:
   main:
     weight: 30
-description: Cloud Native Sustainability Week is a global event where CNCF community organize local meetups around the topic of cloud native sustainability. Cloud Native Sustainability Week will take place during the second week of October 2023.
+description: Cloud Native Sustainability Week is a global event where the CNCF community organizes local meetings around the theme of Cloud Native Sustainability. The Cloud Native Sustainability Week will take place in the second week of October 2023.
 slug: cloud-native-sustainability-week
 ---
 
@@ -25,41 +25,42 @@ Please take a look at this [document](https://docs.google.com/document/d/1s28lqq
 
 *Note that this list is changing, we will publish a complete overview a few weeks for the event! Take a look at this [document](https://docs.google.com/document/d/1s28lqqc3IBAMw4T7n13zfyAuUEEc3I4_xhPxCLA4_dk/edit#heading=h.19phjl5j6fdw) to check the latest status, and persons to contact.*
 
-| **Nr** | **Name** | **Location** | **Date** | **Event Link** |
+
+
+| **Nr** | **Location** | **Date** | **Event Link** | **Name** |
 |---|---|---|---|---|
-| 1 | Adam Gardner, Prateek Nayak | Australia, Sydney | *tbd* | *tbd* |
-| 2 | Alessandro Vozza | Netherlands, Amsterdam | *tbd* | *tbd* |
-| 3 | Angel Ramirez | Latin America | *tbd* | *tbd* |
-| 4 | Ayrat Khayrettdinov | Canada, Toronto | *tbd* | *tbd* |
-| 5 | Divya Mohan | India | *tbd* | *tbd* |
-| 6 | Johann Gyger | Switzerland, Bern | *tbd* | *tbd* |
-| 7 | Josh Gavant | USA, Chicago | *tbd* | *tbd* |
-| 8 | Kasper Nissen | Denmark, Aarhus | *tbd* | *tbd* |
-| 9 | Kunal Kushwaha | England, London | *tbd* | *tbd* |
-| 10 | Nancy Chauhan | India, Bangalore | *tbd* | *tbd* |
-| 11 | Rynn Mancuso | USA, Oakland | *tbd* | *tbd* |
-| 12 | Seokho Son, Hoon Jo | Korea, Seoul | *tbd* | *tbd* |
-| 13 | Sergio Mendez | Guatemala | *tbd* | *tbd* |
-| 14 | Yiming Peng | USA, Seattle | *tbd* | *tbd* |
-| 15 | Phil Huang | Taiwan, Taipei | *tbd* | *tbd* |
-| 16 | Carol Valencia | Brasil, São Paulo | *tbd* | *tbd* |
-| 17 | Niki Manoledaki | Spain, Barcelona | *tbd* | *tbd* |
-| 18 | Rodolfo Martínez Vega | Mexico, Guadalajara | *tbd* | *tbd* |
-| 19 | Kristina Devochko | Norway, Oslo | *tbd* | *tbd* |
-| 20 | Vinothini B, Manikandan, Vijayabharathi  | India, Chennai | *tbd* | *tbd* |
-| 21 | Stéphane Este-Gracias | Luxembourg, Luxembourg | *tbd* | *tbd* |
-| 22 | Adam Roe | Germany, Berlin | *tbd* | *tbd* |
-| 23 | Aydin Mir Mohammadi | Germany, Karlsruhe | *tbd* | *tbd* |
-| 24 | Leonard Pahlke | Germany, Hamburg | *tbd* | *tbd* |
-| 25 | Michel Murabito | Italy, Milan | *tbd* | *tbd* |
-| 26 | Antonio Di Turi, Max Körbächer | Germany, Munich | *tbd* | *tbd* |
+| 1 | Australia, Sydney | *tbd* |  *tbd* | Adam Gardner, Prateek Nayak |
+| 2 | Brasil, São Paulo | *tbd* |  *tbd* | Carol Valencia |
+| 3 | Canada, Toronto |  *tbd* |  *tbd* | Ayrat Khayrettdinov |
+| 4 | Denmark, Aarhus |  *tbd* |  *tbd* | Kasper Nissen |
+| 5 | England, London |  *tbd* |  *tbd* | Kunal Kushwaha |
+| 6 | Germany, Hamburg | *tbd* | *tbd* | Leonard Pahlke |
+| 7 | Germany, Karlsruhe | *tbd* | *tbd* | Aydin Mir Mohammadi |
+| 8 | Germany, Munich | *tbd* | *tbd* | Antonio Di Turi, Max Körbächer |
+| 9 | Germany, Berlin | *tbd* | *tbd* | Adam Roe |
+| 10 | Guatemala | *tbd* | *tbd* | Sergio Mendez |
+| 11 | India, Bangalore | *tbd* | *tbd* | Nancy Chauhan, Divya Mohan |
+| 12 | India, Chennai | *tbd* | *tbd* | Vinothini B, Manikandan, Vijayabharathi |
+| 13 | Italy, Milan | *tbd* | *tbd* | Michel Murabito |
+| 14 | Korea, Seoul | *tbd* | *tbd* | Seokho Son, Hoon Jo |
+| 15 | Latin America | *tbd* | *tbd* | Angel Ramirez |
+| 16 | Luxembourg, Luxembourg | *tbd* | *tbd* | Stéphane Este-Gracias |
+| 17 | Mexico, Guadalajara | *tbd* | *tbd* | Rodolfo Martínez Vega |
+| 18 | Netherlands, Amsterdam | *tbd* | *tbd* | Alessandro Vozza |
+| 19 | Norway, Oslo | *tbd* | *tbd* | Kristina Devochko |
+| 20 | Spain, Barcelona | *tbd* | *tbd* | Niki Manoledaki |
+| 21 | Switzerland, Bern | *tbd* | *tbd* | Johann Gyger |
+| 22 | Taiwan, Taipei | *tbd* | *tbd* | Phil Huang |
+| 23 | USA, Chicago | *tbd* | *tbd* | Josh Gavant |
+| 24 | USA, Oakland | *tbd* | *tbd* | Rynn Mancuso |
+| 25 | USA, Seattle | *tbd* | *tbd* | Yiming Peng|
 
 ## Event Goals
 
 1. **Gain better insights into the current [cloud native environmental sustainability landscape](https://tag-env-sustainability.cncf.io/about/landscape/)**: Engage with the community and IT industry as a whole to develop a deeper understanding of the [cloud native environmental sustainability landscape](https://tag-env-sustainability.cncf.io/about/landscape/).  
 2. **Identify knowledge gaps**: Recognize domain areas for cloud native environmental sustainability where further exploration and knowledge sharing is needed.
 3. **Foster project collaboration**: Encourage participants to actively collaborate on further development and improvement of existing projects and tools that pertain to the field of cloud native sustainability.
-4. **Raise awareness**: Increase awareness: Enhance awareness and knowledge sharing around the topic of cloud native environmental sustainability.
+4. **Raise awareness**: Enhance awareness and knowledge sharing around the topic of cloud native environmental sustainability.
 5. **Promote TAG ENV and CNCF**: Promoting the #tag-environmental-sustainability and raising awareness about the CNCF in general.
 6. **Survey**: distributing a survey to gather information on end user adoption of cloud native sustainability.
 7. **Badges**: providing badges from credly for organizers and potentially speakers.

--- a/website/content/cloud-native-sustainability-week/_index.md
+++ b/website/content/cloud-native-sustainability-week/_index.md
@@ -1,13 +1,21 @@
 ---
 title: CNCF Cloud Native Sustainability Week
-description: Cloud Native Sustainability Week is an event to organize meetings in CNCF community groups around the theme of Cloud Native Sustainability during the second week of October 2023.
+linkTitle: Cloud Native Sustainability Week
+toc_hide: true
+exclude_search: true
+menu:
+  main:
+    weight: 30
+description: Cloud Native Sustainability Week is a global event where CNCF community organize local meetups around the topic of cloud native sustainability. Cloud Native Sustainability Week will take place during the second week of October 2023.
 slug: cloud-native-sustainability-week
 ---
 
-The CNCF Global Week of Cloud Native Sustainability is an event organized by the [Cloud Native Computing Foundation (CNCF)](http://cncf.io) community to address the emerging topic of environmental sustainability in the cloud native industry and open-source space. The event aims to engage with the community and industry, understand the current landscape, and promote collaboration and knowledge sharing.
+The CNCF Global Week of Cloud Native Sustainability is an event organized by the [Cloud Native Computing Foundation (CNCF)](http://cncf.io) community to address the emerging topic of environmental sustainability in the cloud native industry and open source space. The event aims to engage with the community and IT industry as a whole, get a better understanding of the current environmental sustainability landscape, and promote collaboration and knowledge sharing on the topic.
 
-During the **second week of October 2023 (W41)**, the [broader Cloud Native community](https://community.cncf.io/chapters/) will organize meetups in their cities with a focus on cloud native sustainability. These meetups can be organized by anyone interested in supporting the effort. Additionally, the [CNCF Environmental Sustainability Technical Advisory Group (TAG ENV)](http://github.com/cncf/tag-env-sustainability), will host a virtual meetup using the [bevy](http://bevy.com) platform.
+During the **second week of October 2023 (W41)**, the [CNCF community groups around the globe](https://community.cncf.io/chapters/) will organize meetups in their cities with a focus on cloud native sustainability. These meetups can be organized by anyone interested in supporting the effort. Additionally, the [CNCF Environmental Sustainability Technical Advisory Group (TAG ENV)](http://github.com/cncf/tag-env-sustainability), will host a virtual meetup using the [bevy](http://bevy.com) platform.
+These meetups can be organized by anyone interested in supporting the effort. If you would like to contribute, check out the [Contact and Resources](#contact-and-resources) section below.
 
+There will be two types of events organized during the Cloud Native Sustainability Week:
 1. **Local in-person events**: Meetups organized worldwide during the second week of October 2023 by [CNCF community groups](https://community.cncf.io/chapters/) about cloud native sustainability.
 2. **Virtual Event**: A virtual meetup organized by the CNCF TAG ENV.
 
@@ -44,13 +52,14 @@ Please take a look at this [document](https://docs.google.com/document/d/1s28lqq
 | 23 | Aydin Mir Mohammadi | Germany, Karlsruhe | *tbd* | *tbd* |
 | 24 | Leonard Pahlke | Germany, Hamburg | *tbd* | *tbd* |
 | 25 | Michel Murabito | Italy, Milan | *tbd* | *tbd* |
+| 26 | Antonio Di Turi, Max Körbächer | Germany, Munich | *tbd* | *tbd* |
 
 ## Event Goals
 
-1. **Understand the current [landscape](https://tag-env-sustainability.cncf.io/about/landscape/)**: Engaging with the community and industry to better understand the [landscape](https://tag-env-sustainability.cncf.io/about/landscape/) of cloud native environmental sustainability.
-2. **Identify Knowledge Gaps**: Identifying areas of knowledge gaps and further exploration in cloud native environmental sustainability.
-3. **Foster project collaboration**: Facilitating collaboration among participants on ongoing projects and tools related to cloud native sustainability.
-4. **Raise awareness**: Increasing awareness and knowledge about cloud native environmental sustainability.
+1. **Gain better insights into the current [cloud native environmental sustainability landscape](https://tag-env-sustainability.cncf.io/about/landscape/)**: Engage with the community and IT industry as a whole to develop a deeper understanding of the [cloud native environmental sustainability landscape](https://tag-env-sustainability.cncf.io/about/landscape/).  
+2. **Identify knowledge gaps**: Recognize domain areas for cloud native environmental sustainability where further exploration and knowledge sharing is needed.
+3. **Foster project collaboration**: Encourage participants to actively collaborate on further development and improvement of existing projects and tools that pertain to the field of cloud native sustainability.
+4. **Raise awareness**: Increase awareness: Enhance awareness and knowledge sharing around the topic of cloud native environmental sustainability.
 5. **Promote TAG ENV and CNCF**: Promoting the #tag-environmental-sustainability and raising awareness about the CNCF in general.
 6. **Survey**: distributing a survey to gather information on end user adoption of cloud native sustainability.
 7. **Badges**: providing badges from credly for organizers and potentially speakers.
@@ -69,12 +78,12 @@ If you are a meetup organizer, we have a [tracking issue](https://github.com/cnc
 
 ## Acknowledgements ✨
 
-The event is organized by volunteers in their spare time. Its truly a community effort without that this would not be possible. Thanks everyone for helping!
+The event is organized solely by volunteers who dedicate their spare time, making it a true community effort. Without the collective contributions of everyone involved, this event would not have been possible. Thank you to each and every community member for your support and contributions!
 
-Special thanks to Nancy Chauhan, Adriana Villela, Kristina Devochko, Niki Manoledaki, Mercy Bamiduro, Mehmet, Rodolfo Martínez Vega and Leonard Pahlke to help organise the event.
+Special thanks to Adriana Villela, Kristina Devochko, Leonard Pahlke, Nancy Chauhan, Niki Manoledaki, Mercy Bamiduro, Mehmet and Rodolfo Martínez Vega to help organise the event.
 
 Special thanks to all the local meetup organizers.
 
-Special thanks to Katie Gamanji, Ricardo Rocha, Wojtek Cichoń, Nikhita Raghunath, Tom Kerkhove, Alena Prokharchyk, Abdel Sghiouar, Huamin Chen, Nate W. and Emily Fox for facilitating, sharing their thoughts and reaching out to people that might be interested organizing a meetup.
+Special thanks to Abdel Sghiouar, Alena Prokharchyk, Emily Fox, Huamin Chen, Katie Gamanji, Nate W., Nikhita Raghunath, Ricardo Rocha, Tom Kerkhove and Wojtek Cichoń for facilitating, sharing their thoughts and reaching out to people that might be interested organizing a meetup.
 
 Special thanks to Katie Greenly and the entire CNCF team for their support.


### PR DESCRIPTION
ref: https://github.com/cncf/tag-env-sustainability/issues/132

This PR adds a page about the cloud native sustainability week (#95) to https://tag-env-sustainability.cncf.io/about/ 

cc @guidemetothemoon 