### PR TITLE
Update for Issue 152 - Include development/testing in Landscape

### DIFF
--- a/website/content/about/SustainabilityUseCasesAndLandscape2023.md
+++ b/website/content/about/SustainabilityUseCasesAndLandscape2023.md
@@ -169,6 +169,15 @@ In either case, AI/Ml clusters often  have the added complexity of XPUs, or acce
 These accelerators take significant amounts of power to run, more by an order of magnitude required from regular computer chips.
 Additionally, some of the workloads on these clusters are not time-sensitive, for instance training sets of information, and some are time-sensitive, for instance inference jobs for recognition systems.
 
+#### Software Development and Testing
+While a concentration is made on the sustainability of active services used by consumers a major factor in the overall footprint of cloud
+sustainability is in the development and testing of the software that these services use. 
+The environmental footprint of the development of software has the same factors that effect it as actual services running but they may be weighted differently. 
+Examples of the types of loads during software development are the individual hardware costs of the developers, the build servers for the software and the various testing stages in the creation of services. 
+Each of these stages are necessary for the development of software but incur an environmental cost. The different loads can be addressed in different ways with flexibility that are different from the sector specific challenges that the software is being produced for. 
+Examples of this is that the testing of Telecoms software might not be as time critical as the production deployments and this gives different flexibility. While there can be some greater flexibility with the location of build servers there will still be speed constraints and developer efficiency is important. 
+The location and utilization of test systems which can be long running and large would seem to be an area of a lot of concern as they can sometimes be of the same order of magnitude as the active deployed systems.
+
 ## Layers of the solutions
 When considering solutions complimentary to the three foundations of sustainable cloud systems, we can divide solution considerations into three general areas:
 

--- a/website/content/about/SustainabilityUseCasesAndLandscape2023.md
+++ b/website/content/about/SustainabilityUseCasesAndLandscape2023.md
@@ -172,7 +172,7 @@ Additionally, some of the workloads on these clusters are not time-sensitive, fo
 #### Software Development and Testing
 Usually, the primary focus of environmental sustainability is restricted to active services.  However, there is also a substantial footprint that can be attributed to the development and testing of the software these services rely on.
 This footprint may be weighted differently than the one of the services.
-Examples of the types of loads during software development are the individual hardware costs of the developers, the build servers for the software and the various testing stages in the creation of services. 
+Some examples of these loads during software development are the individual hardware costs of the developers, the build servers for the software, and the various testing stages in the creation of services. 
 Each of these stages are necessary for the development of software but incur an environmental cost. The different loads can be addressed in different ways with flexibility that are different from the sector specific challenges that the software is being produced for. 
 Examples of this is that the testing of Telecoms software might not be as time critical as the production deployments and this gives different flexibility. While there can be some greater flexibility with the location of build servers there will still be speed constraints and developer efficiency is important. 
 The location and utilization of test systems which can be long running and large would seem to be an area of a lot of concern as they can sometimes be of the same order of magnitude as the active deployed systems.

--- a/website/content/about/SustainabilityUseCasesAndLandscape2023.md
+++ b/website/content/about/SustainabilityUseCasesAndLandscape2023.md
@@ -178,6 +178,7 @@ Each of these stages are necessary for the development of software but incur an 
 Examples of this is that the testing of Telecoms software might not be as time critical as the production deployments and this gives different flexibility. While there can be some greater flexibility with the location of build servers there will still be speed constraints and developer efficiency is important. 
 The location and utilization of test systems which can be long running and large would seem to be an area of a lot of concern as they can sometimes be of the same order of magnitude as the active deployed systems.
 
+
 ## Layers of the solutions
 When considering solutions complimentary to the three foundations of sustainable cloud systems, we can divide solution considerations into three general areas:
 

--- a/website/content/about/SustainabilityUseCasesAndLandscape2023.md
+++ b/website/content/about/SustainabilityUseCasesAndLandscape2023.md
@@ -170,7 +170,7 @@ These accelerators take significant amounts of power to run, more by an order of
 Additionally, some of the workloads on these clusters are not time-sensitive, for instance training sets of information, and some are time-sensitive, for instance inference jobs for recognition systems.
 
 #### Software Development and Testing
-While a concentration is made on the sustainability of active services used by consumers a major factor in the overall footprint of cloud
+Usually, the primary focus of environmental sustainability is restricted to active services.  However, there is also a substantial footprint that can be attributed to the development and testing of the software these services rely on.
 sustainability is in the development and testing of the software that these services use. 
 The environmental footprint of the development of software has the same factors that effect it as actual services running but they may be weighted differently. 
 Examples of the types of loads during software development are the individual hardware costs of the developers, the build servers for the software and the various testing stages in the creation of services. 

--- a/website/content/about/SustainabilityUseCasesAndLandscape2023.md
+++ b/website/content/about/SustainabilityUseCasesAndLandscape2023.md
@@ -171,7 +171,7 @@ Additionally, some of the workloads on these clusters are not time-sensitive, fo
 
 #### Software Development and Testing
 Usually, the primary focus of environmental sustainability is restricted to active services.  However, there is also a substantial footprint that can be attributed to the development and testing of the software these services rely on.
-The environmental footprint of the development of software has the same factors that effect it as actual services running but they may be weighted differently. 
+This footprint may be weighted differently than the one of the services.
 Examples of the types of loads during software development are the individual hardware costs of the developers, the build servers for the software and the various testing stages in the creation of services. 
 Each of these stages are necessary for the development of software but incur an environmental cost. The different loads can be addressed in different ways with flexibility that are different from the sector specific challenges that the software is being produced for. 
 Examples of this is that the testing of Telecoms software might not be as time critical as the production deployments and this gives different flexibility. While there can be some greater flexibility with the location of build servers there will still be speed constraints and developer efficiency is important. 

--- a/website/content/about/SustainabilityUseCasesAndLandscape2023.md
+++ b/website/content/about/SustainabilityUseCasesAndLandscape2023.md
@@ -175,7 +175,7 @@ This footprint may be weighted differently than the one of the services.
 Some examples of these loads during software development are the individual hardware costs of the developers, the build servers for the software, and the various testing stages in the creation of services. 
 Each of these stages is necessary for the development of software, but they do incur an environmental cost. These loads should be addressed in a way that makes sense for this area. 
 Examples of this is that the testing of Telecoms software might not be as time critical as the production deployments and this gives different flexibility. While there can be some greater flexibility with the location of build servers there will still be speed constraints and developer efficiency is important. 
-The location and utilization of test systems which can be long running and large would seem to be an area of a lot of concern as they can sometimes be of the same order of magnitude as the active deployed systems.
+These test systems may still be large and long-run, but would seem to be an area of concern regarding sustainability optimization for the full system.
 
 
 ## Layers of the solutions

--- a/website/content/about/SustainabilityUseCasesAndLandscape2023.md
+++ b/website/content/about/SustainabilityUseCasesAndLandscape2023.md
@@ -173,7 +173,7 @@ Additionally, some of the workloads on these clusters are not time-sensitive, fo
 Usually, the primary focus of environmental sustainability is restricted to active services.  However, there is also a substantial footprint that can be attributed to the development and testing of the software these services rely on.
 This footprint may be weighted differently than the one of the services.
 Some examples of these loads during software development are the individual hardware costs of the developers, the build servers for the software, and the various testing stages in the creation of services. 
-Each of these stages are necessary for the development of software but incur an environmental cost. The different loads can be addressed in different ways with flexibility that are different from the sector specific challenges that the software is being produced for. 
+Each of these stages is necessary for the development of software, but they do incur an environmental cost. These loads should be addressed in a way that makes sense for this area. 
 Examples of this is that the testing of Telecoms software might not be as time critical as the production deployments and this gives different flexibility. While there can be some greater flexibility with the location of build servers there will still be speed constraints and developer efficiency is important. 
 The location and utilization of test systems which can be long running and large would seem to be an area of a lot of concern as they can sometimes be of the same order of magnitude as the active deployed systems.
 

--- a/website/content/about/SustainabilityUseCasesAndLandscape2023.md
+++ b/website/content/about/SustainabilityUseCasesAndLandscape2023.md
@@ -174,7 +174,7 @@ Usually, the primary focus of environmental sustainability is restricted to acti
 This footprint may be weighted differently than the one of the services.
 Some examples of these loads during software development are the individual hardware costs of the developers, the build servers for the software, and the various testing stages in the creation of services. 
 Each of these stages is necessary for the development of software, but they do incur an environmental cost. These loads should be addressed in a way that makes sense for this area. 
-Examples of this is that the testing of Telecoms software might not be as time critical as the production deployments and this gives different flexibility. While there can be some greater flexibility with the location of build servers there will still be speed constraints and developer efficiency is important. 
+For example, application testing may not need the same availability as production deployments. In the test environment, the positioning of the servers may be less critical, but there will still be speed developer efficiency that should be taken into consideration. 
 These test systems may still be large and long-run, but would seem to be an area of concern regarding sustainability optimization for the full system.
 
 

--- a/website/content/about/SustainabilityUseCasesAndLandscape2023.md
+++ b/website/content/about/SustainabilityUseCasesAndLandscape2023.md
@@ -171,7 +171,6 @@ Additionally, some of the workloads on these clusters are not time-sensitive, fo
 
 #### Software Development and Testing
 Usually, the primary focus of environmental sustainability is restricted to active services.  However, there is also a substantial footprint that can be attributed to the development and testing of the software these services rely on.
-sustainability is in the development and testing of the software that these services use. 
 The environmental footprint of the development of software has the same factors that effect it as actual services running but they may be weighted differently. 
 Examples of the types of loads during software development are the individual hardware costs of the developers, the build servers for the software and the various testing stages in the creation of services. 
 Each of these stages are necessary for the development of software but incur an environmental cost. The different loads can be addressed in different ways with flexibility that are different from the sector specific challenges that the software is being produced for. 


### PR DESCRIPTION
Update for https://github.com/cncf/tag-env-sustainability/issues/152

This is an initial attempt to include development/testing in the landscape document at the same level as Other workloads. If the conversations leads to other locations or proposals thats all the better. 