### PR TITLE
Adds link checking and fix broken links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ bin/
 # Generated files by hugo
 /website/public
 /website/resources
+!/website/tmp/
+!/website/tmp/.htmltest/
+!/website/tmp/.htmltest/refcache.json
 
 # Executable may be added to repository
 hugo.exe

--- a/website/.htmltest.yml
+++ b/website/.htmltest.yml
@@ -1,0 +1,17 @@
+CacheExpires: 4400h # ~ 6 months
+DirectoryPath: public
+IgnoreInternalURLs: # list of paths
+IgnoreURLs: # list of regexs of paths or URLs to be ignored
+
+  # Sites that deny access, always yielding 403 Forbidden (unless mentioned otherwise)
+  - ^https://(www\.)?linkedin\.com # 999 Request Denied
+  - ^https://www\.researchgate\.net
+  - ^https://twitter\.com
+
+  # Ignore Docsy-generated GitHub links:
+  - ^https?://github\.com/.*?/.*?/(new|edit)/ # view-page, edit-source etc
+  - ^https://github.com/cncf/tag-env-sustainability/commit/ # last mod
+
+  # TODO: fix me! Links that no longer exist
+  - ^https://sci-data.greensoftware.foundation/
+    # Should this link to https://greensoftware.foundation/articles/software-carbon-intensity-sci-specification-project?

--- a/website/content/about/SustainabilityUseCasesAndLandscape2023.ko.md
+++ b/website/content/about/SustainabilityUseCasesAndLandscape2023.ko.md
@@ -12,7 +12,7 @@ toc_hide: true
 운영 탄소 배출량을 정량화하는 것은 가시성과 관리 책임을 위한 도구를 배포하는 것만큼 간단하지 않습니다. 특히 클라우드 컴퓨팅의 경우 서버에 포함된 여러 하드웨어 구성 요소, 클라우드 인프라의 다양한 하드웨어 세대/아키텍처/공급업체, 서비스의 종속성, 가상화/컨테이너화된 환경에서 실행되는 서비스, 서버의 별도 팬/냉각 컨트롤러, 누락된 데이터, 원격 측정 및 가시성, AI/ML 워크로드, 기밀 워크로드 등이 존재하기 때문에 더욱 그러합니다. 이러한 문제로 인해 클라우드 컴퓨팅과 관련된 탄소 배출량을 정확하게 측정하기가 어렵습니다.
 이 백서에서는 클라우드 컴퓨팅의 탄소 및 에너지 회계와 관련된 과제를 살펴보고 퍼블릭 및 프라이빗 클라우드에서 탄소 배출량을 정량화하는 데 따르는 복잡성에 대한 인사이트를 제공합니다. 또한 이 백서에서는 통신 산업과 같은 부문별 과제를 살펴봅니다.
 
-## 목차 
+## 목차
 - [기여자](#contributors)
 - [지속 가능한 클라우드 시스템의 기초](#foundations-of-sustainable-cloud-systems)
 - [지속 가능한 클라우드 시스템 구축의 과제](#challenges-of-sustainable-cloud-systems)
@@ -78,7 +78,7 @@ Huamin Chen, [Marlow Weston](https://github.com/catblade), [Niki Manoledaki](htt
 
 제조 세부 정보('내재된 배출량')가 제조 기술 소비자의 전체적 정량화를 위한 정보에 통합되지 않기 때문에 내재된 탄소 배출량을 정량화하는 것도 매우 어렵습니다. 이는 이 백서의 범위를 벗어나는 것이지만, 관심 있는 독자는 이 [TAG 저장소](https://github.com/cncf/tag-env-sustainability)에 이슈 또는 PR을 제출하여 이러한 배출량을 정량화하기 위한 지침, 모범 사례, 방법, 메커니즘을 제안해 주시기 바랍니다.
 
-<figure><img src="https://learn.greensoftware.foundation/assets/images/06_energy_proportionality_updated-a6941b6c0d261511e74dc2217062373c.png" alt=""><figcaption><p><a href="https://learn.greensoftware.foundation/energy-efficiency/#energy-proportionality">에너지 비례성(Energy Proportionality)</a></p></figcaption></figure>
+<figure><img src="https://learn.greensoftware.foundation/assets/images/06_energy_proportionality_updated-a6941b6c0d261511e74dc2217062373c.png" alt="에너지 비례성(Energy Proportionality)"><figcaption><p><a href="https://learn.greensoftware.foundation/energy-efficiency/#energy-proportionality">에너지 비례성(Energy Proportionality)</a></p></figcaption></figure>
 
 ### 클라우드&#x20;
 
@@ -136,7 +136,7 @@ AWS, Azure, GCP와 같은 퍼블릭 클라우드 제공업체는 사용자가 �
 
 ### 런타임 시스템 전력 측정&#x20;
 
-:green\_book: [2016년까지의 주제와 연구를 요약](https://en.wikipedia.org/wiki/Run-time\_estimation\_of\_system\_and\_sub-system\_level\_power\_consumption)
+:green_book: [2016년까지의 주제와 연구를 요약](https://en.wikipedia.org/wiki/Run-time_estimation_of_system_and_sub-system_level_power_consumption)
 
 ### 에너지 절약 및 탄소 저감&#x20;
 
@@ -182,11 +182,11 @@ flowchart TB
 
 #### 냉각 / BMC
 
-:newspaper: :ice\_cube: OCP 냉각 텔레메트리는 [플랫폼 파워 텔레메트리를 통해 데이터센터 냉각 시설 효율성 향상시킴 ](https://www.opencompute.org/documents/ocp-wp-dcf-improve-data-center-cooling-facility-efficiency-through-platform-power-telemetryr1-0-final-update-pdf)
+:newspaper: :ice_cube: OCP 냉각 텔레메트리는 [플랫폼 파워 텔레메트리를 통해 데이터센터 냉각 시설 효율성 향상시킴 ](https://www.opencompute.org/documents/ocp-wp-dcf-improve-data-center-cooling-facility-efficiency-through-platform-power-telemetryr1-0-final-update-pdf)
 
 데이터센터 운영자는 일반적으로 피크 수요를 충족할 수 있는 충분한 버퍼를 확보하기 위해 시설 용량을 과도하게 프로비저닝합니다. 과도한 프로비저닝은 데이터센터의 총소유비용(TCO)에 큰 부담을 줍니다. 오늘날 데이터센터 관리 스택은 데이터센터 런타임 상태 모니터링을 위해 널리 배포되어 전력, 온도, 리소스 사용률 전반에 걸쳐 수많은 데이터를 수집합니다. 이러한 데이터는 데이터 인텔리전스를 통해 데이터센터 효율성을 최적화할 수 있는 기회를 창출합니다. 이 백서에서는 클라우드 환경에서 전력 추세 예측을 사용하여 냉각 효율을 개선한 사례를 소개했습니다. 한편, 이 백서에서는 하이퍼스케일 데이터센터에서 IT 플랫폼 데이터 기반 시설 제어를 구현할 때 원격 측정 수집, 메시징 메커니즘, 관리 API 등 몇 가지 주요 과제와 설계 고려 사항에 대해 설명했습니다. 솔루션 배포를 위해서는 IT 장치, 시설 및 관리 시스템 간의 효과적인 상호 운용성이 매우 중요하며, 오픈 컴퓨트 프로젝트 설계와 Redfish API를 채택하면 시스템 수준 통합이 쉬워지고 다양한 시스템과 다양한 제조업체에 대한 배포 비용을 절감할 수 있습니다.
 
-:ice\_cube: BMC 텔레메트리는 [베이스보드 관리 컨트롤러(BMC, Baseboard Management Controller) 데이터를 Prometheus 형식으로 노출](https://github.com/gebn/bmc\_exporter)
+:ice_cube: BMC 텔레메트리는 [베이스보드 관리 컨트롤러(BMC, Baseboard Management Controller) 데이터를 Prometheus 형식으로 노출](https://github.com/gebn/bmc_exporter)
 
 ### 방법론
 
@@ -198,7 +198,7 @@ flowchart TB
 
 [SCI 지침 ](https://sci-data.greensoftware.foundation/)- SCI 지침 프로젝트는 SCI 계산의 핵심 구성 요소인 에너지, 탄소 집약도, 구체화된 배출량 및 기능 단위값을 계산하는 데 사용할 수 있는 다양한 방법론을 이해하는 방법에 대한 다양한 접근 방식을 자세히 설명합니다.
 
-런타임(Runtime) - 시스템 전력 소비량 추정 런타임을 통해 [시스템 및 하위 시스템 수준의 전력 소비량에 대한 런타임 예측](https://en.wikipedia.org/wiki/Run-time\_estimation\_of\_system\_and\_sub-system\_level\_power\_consumption)
+런타임(Runtime) - 시스템 전력 소비량 추정 런타임을 통해 [시스템 및 하위 시스템 수준의 전력 소비량에 대한 런타임 예측](https://en.wikipedia.org/wiki/Run-time_estimation_of_system_and_sub-system_level_power_consumption)
 
 #### 관측 가능성 방법론 &#x20;
 
@@ -253,7 +253,7 @@ flowchart TB
 
 :eyes: [그린 메트릭 도구](https://docs.green-coding.berlin/) - 애플리케이션의 에너지/탄소 배출량을 측정하기 위한 종합적인 프레임워크입니다.
 
-:eyes: [InfluxData 텔레그래프 수집기](https://github.com/influxdata/telegraf) - 메트릭 수집, 처리, 집계, 작성을 위한 오픈 소스 플러그인 기반 에이전트입니다. 에너지 소비량을 파악하는 데 도움이 되는 여러 입력 플러그인(예: [intel\_powerstat](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/intel\_powerstat)(CPU 및 DRAM 전력 소비량, CPU 온도, TDP, CPU 및 Uncore 주파수, C-State 레지던시 노출), [ipmi\_sensor](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/ipmi\_sensor)(IPMI 센서 데이터 노출), [redfish](https://redfish.dmtf.org/)(DMTF의 Redfish 인터페이스에서 노출되는 CPU 온도, 팬 속도, 전원 공급 및 전압 데이터 노출), 개별 자원의 활용도를 파악하여 전력 소비 위치를 파악하는 데 도움이 되는 많은 플러그인이 포함되어 있습니다. 사용 가능한 풍부한 출력 플러그인 세트를 통해 다양한 메트릭 대상과 쉽게 통합할 수 있습니다.
+:eyes: [InfluxData 텔레그래프 수집기](https://github.com/influxdata/telegraf) - 메트릭 수집, 처리, 집계, 작성을 위한 오픈 소스 플러그인 기반 에이전트입니다. 에너지 소비량을 파악하는 데 도움이 되는 여러 입력 플러그인(예: [intel_powerstat](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/intel_powerstat)(CPU 및 DRAM 전력 소비량, CPU 온도, TDP, CPU 및 Uncore 주파수, C-State 레지던시 노출), [ipmi_sensor](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/ipmi_sensor)(IPMI 센서 데이터 노출), [redfish](https://redfish.dmtf.org/)(DMTF의 Redfish 인터페이스에서 노출되는 CPU 온도, 팬 속도, 전원 공급 및 전압 데이터 노출), 개별 자원의 활용도를 파악하여 전력 소비 위치를 파악하는 데 도움이 되는 많은 플러그인이 포함되어 있습니다. 사용 가능한 풍부한 출력 플러그인 세트를 통해 다양한 메트릭 대상과 쉽게 통합할 수 있습니다.
 
 :eyes: [Carbon QL](https://github.com/Green-Software-Foundation/carbon-ql) - 이 프로젝트의 목적은 모든 런타임 환경에서 소프트웨어 배출량을 측정하는 데 사용할 수 있는 코드명 carbonQL이라는 단일 API를 구축하는 것입니다.
 
@@ -263,9 +263,9 @@ flowchart TB
 
 :eyes: [PowerTOP](https://github.com/fenrus75/powertop) - Linux 도구로, 무엇보다도 Linux 시스템에서 실행 중인 프로세스당 전력 소비를 모니터링할 수 있습니다.
 
-:green\_book: OSTI \[논문] [복원력 있는 HPC 시스템을 위한 에너지 절약 기법 평가를 위한 메트릭](https://www.osti.gov/biblio/1140455)
+:green_book: OSTI \[논문] [복원력 있는 HPC 시스템을 위한 에너지 절약 기법 평가를 위한 메트릭](https://www.osti.gov/biblio/1140455)
 
-:green\_book: [Carbon Aware SDK](https://github.com/Green-Software-Foundation/carbon-aware-sdk) - 탄소 인식 소프트웨어 구축을 지원하는 웹에이피 및 명령줄 인터페이스(CLI)입니다.
+:green_book: [Carbon Aware SDK](https://github.com/Green-Software-Foundation/carbon-aware-sdk) - 탄소 인식 소프트웨어 구축을 지원하는 웹에이피 및 명령줄 인터페이스(CLI)입니다.
 
 
 
@@ -315,9 +315,9 @@ flowchart TB
 * :train: [인텐트 중심 오케스트레이션](https://github.com/intel/intent-driven-orchestration) \
   이는 워크로드 배치를 선택하기 위해 명령형 모델에서 인텐트 중심 모델로 이동하여 오케스트레이션을 수행하는 새로운 방법을 제공합니다. 이 모델에서는 사용자가 목표(예: 필요한 지연 시간, 처리량 또는 안정성 목표)의 형태로 의도를 표현하고, 오케스트레이션 스택 자체가 목표를 달성하는 데 필요한 인프라의 리소스를 결정합니다. 이 새로운 접근 방식은 스케줄링(워크로드를 배치할 시기와 위치 결정)에 대한 커뮤니티의 투자를 계속 활용할 수 있으며, 시스템에서 무엇을 어떻게 구성할지 결정하는 지속적인 실행 계획 루프를 통해 보강될 것입니다. 전력 최적 사용 환경에서 이를 활용하기 위한 예비 작업이 이미 진행 중입니다.
 
-:green\_book: 탄소 감지 쿠버네티스 스케줄러 - [저탄소 쿠버네티스 스케줄러](https://ceur-ws.org/Vol-2382/ICT4S2019\_paper\_28.pdf)
+:green_book: 탄소 감지 쿠버네티스 스케줄러 - [저탄소 쿠버네티스 스케줄러](https://ceur-ws.org/Vol-2382/ICT4S2019_paper_28.pdf)
 
-:green\_book: 에너지 인지 스케줄링 \[백서] [Kubernetes의 전체적인 스케줄링을 통한 데이터센터 효율성 향상](https://www.researchgate.net/publication/333062266\_Improving\_Data\_Center\_Efficiency\_Through\_Holistic\_Scheduling\_In\_Kubernetes)
+:green_book: 에너지 인지 스케줄링 \[백서] [Kubernetes의 전체적인 스케줄링을 통한 데이터센터 효율성 향상](https://www.researchgate.net/publication/333062266_Improving_Data_Center_Efficiency_Through_Holistic_Scheduling_In_Kubernetes)
 
 ### 스케일링
 
@@ -331,11 +331,11 @@ flowchart TB
 
 지역과 노드가 선택되면 관리자와 사용자는 워크로드를 실행하는 데 필요한 전력량을 최소화하도록 노드를 추가로 조정할 수 있습니다. 이렇게 하면 노드당 전력을 30% 이상 줄일 수 있습니다.
 
-* :musical\_note: [OCP에서 TuneD를 통한 노드 튜닝](https://docs.openshift.com/container-platform/4.10/scalability\_and\_performance/using-node-tuning-operator.html) - 튜닝된 데몬을 오케스트레이션하여 노드 수준 튜닝을 관리\
+* :musical_note: [OCP에서 TuneD를 통한 노드 튜닝](https://docs.openshift.com/container-platform/4.10/scalability_and_performance/using-node-tuning-operator.html) - 튜닝된 데몬을 오케스트레이션하여 노드 수준 튜닝을 관리\
   노드 튜닝 오퍼레이터는 TuneD 데몬을 오케스트레이션하여 노드 수준 튜닝을 관리할 수 있도록 도와줍니다. 대부분의 고성능 애플리케이션에는 일정 수준의 커널 튜닝이 필요합니다. 노드 튜닝 오퍼레이터는 노드 수준 sysctl 사용자에게 통합 관리 인터페이스를 제공하고 사용자 요구에 따라 지정된 커스텀 튜닝을 추가할 수 있는 유연성을 제공합니다.
-* :musical\_note: [쿠버네티스 파워 매니저](https://github.com/intel/kubernetes-power-manager) - 쿠버네티스 오퍼레이터는 쿠버네티스 환경에서 인텔의 특정 전원 관리 기술을 노출하고 활용하도록 설계되어짐\
+* :musical_note: [쿠버네티스 파워 매니저](https://github.com/intel/kubernetes-power-manager) - 쿠버네티스 오퍼레이터는 쿠버네티스 환경에서 인텔의 특정 전원 관리 기술을 노출하고 활용하도록 설계되어짐\
   &#x20;Kubernetes(K8s)와 같은 컨테이너 오케스트레이션 엔진의 플랫폼 풀에서 CPU 리소스를 할당하는 것은 전적으로 가용성에 기반합니다. 쿠버네티스 컨텍스트에서 전원 관리 기술을 노출하고 사용하기 위해, 쿠버네티스 파워 매니저는 오퍼레이터 SDK를 사용하여 생성된 쿠버네티스 오퍼레이터이다. 쿠버네티스 파워 매니저는 강력한 전원 관리 기술 세트를 사용하여 사용자가 코어별로 CPU 성능과 전력 사용량을 보다 정밀하게 제어할 수 있도록 해준다. 그러나 쿠버네티스는 워크로드와 워크로드 오케스트레이터와 같은 하드웨어 기능 사이의 추상화 계층으로 작동하도록 의도적으로 구축되었습니다. 하드웨어 기능에 의존하는 특정 요구사항이 있는 성능 크리티컬 애플리케이션을 실행하는 Kubernetes 사용자는 이로 인해 장애물이 있습니다. 사용자가 주파수를 조정하고 쿠버네티스 네이티브 CPU 매니저가 선택한 코어의 우선순위 수준을 결정할 수 있게 함으로써, 쿠버네티스 파워 매니저는 하드웨어 기능 활성화와 컨테이너 오케스트레이션 레이어 사이의 간극을 메웁니다. 또한, 다양한 주파수 튜닝에 따라 노드의 전원을 제어하는 데 사용되는 TuneD 프로파일을 사용할 수 있도록 TuneD와 함께 작동하는 것으로 입증되었습니다.
-* :musical\_note: [GEOPM](https://github.com/geopm/geopm) - [확장형 전원 관리자](https://geopm.github.io/)\
+* :musical_note: [GEOPM](https://github.com/geopm/geopm) - [확장형 전원 관리자](https://geopm.github.io/)\
   처음에는 HPC 환경에 특화되어 있었지만 현재는 보다 일반화된 GEOPM(Global Extensible Open Power Manager)은 이기종 플랫폼에서 전력 및 에너지 최적화를 탐색하기 위한 프레임워크입니다. GEOPM 소프트웨어는 두 가지 패키지로 나뉩니다: GEOPM 서비스와 GEOPM 런타임입니다. GEOPM 서비스는 저수준 하드웨어 메트릭 및 구성 노브에 대한 사용자 공간 액세스를 제공합니다. GEOPM 런타임은 하드웨어 메트릭 및 애플리케이션 피드백에 반응하여 하드웨어 설정을 조정하기 위해 GEOPM 서비스를 활용합니다. 애플리케이션 피드백은 미들웨어 패키지에 콜백으로 삽입된 경량 비동기 프로파일링 후크를 통해 수집됩니다. GEOPM 런타임에는 최적화 알고리즘을 선택할 수 있는 플러그인 아키텍처가 있습니다. 기본 제공 알고리즘 중 일부는 에너지 효율성을 목표로 하고, 다른 알고리즘은 전력 제한 내에서 성능을 최적화합니다. GEOPM을 Kubernetes로 포팅하는 작업은 현재 진행 중입니다. 클라우드(cloud)라는 [실험 브랜치](https://github.com/geopm/geopm/tree/cloud#experimental-branch)에는 Kubernetes를 지원하는 새로운 기능이 구현되어 있습니다. 이러한 기능은 각각 프로덕션 준비가 되면 메인 개발 브랜치로 마이그레이션될 예정입니다. 추가 설명서는 서비스 [readme](https://github.com/geopm/geopm/tree/cloud/service#kubernetes-support) 파일과 [런타임 k8 디렉터리](https://github.com/geopm/geopm/tree/cloud/k8)에서 찾을 수 있습니다.
 
 
@@ -366,27 +366,27 @@ flowchart TB
 
 ### 탄소 배출량 보고서
 
-:page\_facing\_up: IEA 배출량 - [2019년 글로벌 에너지 및 CO2 현황 보고서](https://www.iea.org/reports/global-energy-co2-status-report-2019/emissions)
+:page_facing_up: IEA 배출량 - [2019년 글로벌 에너지 및 CO2 현황 보고서](https://www.iea.org/reports/global-energy-co2-status-report-2019/emissions)
 
-:page\_facing\_up: 유럽 환경청 - [EU 온실가스 배출 강도](https://www.eea.europa.eu/ims/greenhouse-gas-emission-intensity-of-1)&#x20;
+:page_facing_up: 유럽 환경청 - [EU 온실가스 배출 강도](https://www.eea.europa.eu/ims/greenhouse-gas-emission-intensity-of-1)&#x20;
 
-:page\_facing\_up: [전력지도 ](https://app.electricitymaps.com/map)- 실시간 CO2 배출량 데이터&#x20;
+:page_facing_up: [전력지도 ](https://app.electricitymaps.com/map)- 실시간 CO2 배출량 데이터&#x20;
 
 [SCI 보고](https://github.com/Green-Software-Foundation/sci-reporting) - SCI 점수를 저장, 호스팅 및 공개적으로 보고하기 위한 인프라와 프로세스를 생성하고, SCI 사양 내에서 기타 관련 보고 요건을 충족합니다.&#x20;
 
-:page\_facing\_up: [WattTime API ](https://www.watttime.org/api-documentation/#introduction)- 전력망의 한계 배출률에 대한 인사이트 제공
+:page_facing_up: [WattTime API ](https://www.watttime.org/api-documentation/#introduction)- 전력망의 한계 배출률에 대한 인사이트 제공
 
 ### 넷 제로 / 탄소 중립
 
-:leafy\_green: [2040년까지 탄소중립](https://www.theclimatepledge.com/)을 달성하겠다는 기후 서약
+:leafy_green: [2040년까지 탄소중립](https://www.theclimatepledge.com/)을 달성하겠다는 기후 서약
 
-:leafy\_green: WeTransfer - [기후 중립을 실현하는 Wetransfer](https://wetransfer.com/blog/story/breaking-the-climate-neutral-barrier/)&#x20;
+:leafy_green: WeTransfer - [기후 중립을 실현하는 Wetransfer](https://wetransfer.com/blog/story/breaking-the-climate-neutral-barrier/)&#x20;
 
-:leafy\_green: Adrian Cockroft, 전 Amazon 지속 가능성 아키텍처 부사장 "[클라우드 컴퓨팅 선구자의 새로운 초점은 지속 가능성 혁신에 있습니다.](https://www.aboutamazon.com/news/sustainability/cloud-computing-pioneers-new-focus-is-on-sustainability-transformation)"&#x20;
+:leafy_green: Adrian Cockroft, 전 Amazon 지속 가능성 아키텍처 부사장 "[클라우드 컴퓨팅 선구자의 새로운 초점은 지속 가능성 혁신에 있습니다.](https://www.aboutamazon.com/news/sustainability/cloud-computing-pioneers-new-focus-is-on-sustainability-transformation)"&#x20;
 
-:leafy\_green: 슈퍼크리티컬 기업의 [탄소중립 달성 지원](https://gosupercritical.com/)
+:leafy_green: 슈퍼크리티컬 기업의 [탄소중립 달성 지원](https://gosupercritical.com/)
 
 ### 프로그래밍 언어 효율성 분석
 
-:electric\_plug:: 프로그래밍 언어의 에너지 효율 - [컴퓨터 언어 벤치마크 게임을 통해 프로그래밍 언어의 에너지 소비를 분석하는 도구](https://github.com/greensoftwarelab/Energy-Languages)
+:electric_plug:: 프로그래밍 언어의 에너지 효율 - [컴퓨터 언어 벤치마크 게임을 통해 프로그래밍 언어의 에너지 소비를 분석하는 도구](https://github.com/greensoftwarelab/Energy-Languages)
 

--- a/website/content/cloud-native-sustainability-week/_index.md
+++ b/website/content/cloud-native-sustainability-week/_index.md
@@ -12,7 +12,7 @@ slug: cloud-native-sustainability-week
 
 The CNCF Global Week of Cloud Native Sustainability is an event organized by the [Cloud Native Computing Foundation (CNCF)](http://cncf.io) community to address the emerging topic of environmental sustainability in the cloud native industry and open source space. The event aims to engage with the community and IT industry as a whole, get a better understanding of the current environmental sustainability landscape, and promote collaboration and knowledge sharing on the topic.
 
-During the **second week of October 2023 (W41)**, the [CNCF community groups around the globe](https://community.cncf.io/chapters/) will organize meetups in their cities with a focus on cloud native sustainability. These meetups can be organized by anyone interested in supporting the effort. Additionally, the [CNCF Environmental Sustainability Technical Advisory Group (TAG ENV)](http://github.com/cncf/tag-env-sustainability), will host a virtual meetup using the [bevy](http://bevy.com) platform.
+During the **second week of October 2023 (W41)**, the [CNCF community groups around the globe](https://community.cncf.io/chapters/) will organize meetups in their cities with a focus on cloud native sustainability. These meetups can be organized by anyone interested in supporting the effort. Additionally, the [CNCF Environmental Sustainability Technical Advisory Group (TAG ENV)](http://github.com/cncf/tag-env-sustainability), will host a virtual meetup using the [bevy](https://www.bevy.com) platform.
 These meetups can be organized by anyone interested in supporting the effort. If you would like to contribute, check out the [Contact and Resources](#contact-and-resources) section below.
 
 There will be two types of events organized during the Cloud Native Sustainability Week:
@@ -59,7 +59,7 @@ Please take a look at this [document](https://docs.google.com/document/d/1s28lqq
 
 ## Event Goals
 
-1. **Gain better insights into the current [cloud native environmental sustainability landscape](https://tag-env-sustainability.cncf.io/about/landscape/)**: Engage with the community and IT industry as a whole to develop a deeper understanding of the [cloud native environmental sustainability landscape](https://tag-env-sustainability.cncf.io/about/landscape/).  
+1. **Gain better insights into the current [Cloud Native Sustainability Landscape](/landscape/)**: Engage with the community and IT industry as a whole to develop a deeper understanding of the [Cloud Native Sustainability Landscape](/landscape/).
 2. **Identify knowledge gaps**: Recognize domain areas for cloud native environmental sustainability where further exploration and knowledge sharing is needed.
 3. **Foster project collaboration**: Encourage participants to actively collaborate on further development and improvement of existing projects and tools that pertain to the field of cloud native sustainability.
 4. **Raise awareness**: Enhance awareness and knowledge sharing around the topic of cloud native environmental sustainability.
@@ -75,9 +75,9 @@ Please reach out to us via the [CNCF Slack workspace](https://slack.cncf.io/) in
 If you are a meetup organizer, we have a [tracking issue](https://github.com/cncf/tag-env-sustainability/issues/134) to collect input and questions.
 
 * **General Tracking Issue**: https://github.com/cncf/tag-env-sustainability/issues/95
-* **General Meetup Organizer Guide**: https://docs.google.com/document/d/1s28lqqc3IBAMw4T7n13zfyAuUEEc3I4_xhPxCLA4_dk/edit?usp=sharing 
+* **General Meetup Organizer Guide**: https://docs.google.com/document/d/1s28lqqc3IBAMw4T7n13zfyAuUEEc3I4_xhPxCLA4_dk/edit?usp=sharing
 * **Milestone to track the event organization tasks**: https://github.com/cncf/tag-env-sustainability/milestone/3
-* **Google Drive folder**: https://drive.google.com/drive/folders/1pdBQTxlpvDr0QFIuIpjfERau1IQNfdaX?ths=true 
+* **Google Drive folder**: https://drive.google.com/drive/folders/1pdBQTxlpvDr0QFIuIpjfERau1IQNfdaX?ths=true
 
 ## Acknowledgements ✨
 

--- a/website/content/events/2023-oss-na.md
+++ b/website/content/events/2023-oss-na.md
@@ -7,7 +7,7 @@ weight: 2
 Level up your open source knowledge with access to 15 micro-conferences, including SustainabilityCOn, and 300+ sessions. Join the ultimate gathering of open source innovators to learn, network and collaborate in Vancouver, British Columbia from 10-12 May, 2023.
 And we as a TAG have a few sessions planned on site!
 
-### SustainabilityCon Sessions - [link](https://events.linuxfoundation.org/open-source-summit-north-america/program/schedule/])
+### SustainabilityCon Sessions - [link](https://events.linuxfoundation.org/open-source-summit-north-america/program/schedule/)
 
 Are you interested in the impact your cloud projects and cloud-related work has on the environment?
 Then we would love to meet you at our [**TAG Environmental Sustainability Project Meeting**](https://tockify.com/cncf.public.events/detail/598/1683747900000) at OSS NA.

--- a/website/content/landscape/_index.md
+++ b/website/content/landscape/_index.md
@@ -75,7 +75,7 @@ Furthermore, the paper explores sector-specific challenges, such as the telecomm
 ## Contributors
 A special thank you to our contributors of this document. If you are interested in improving and enhancing the content, please file a PR on the repo and ensure you add yourself as a contributor below!
 
-Huamin Chen, [Marlow Weston](https://github.com/catblade), [Niki Manoledaki](https://github.com/nikimanoledaki), Eun Kyung Lee, [Chen Wang](https://github.com/wangchen615), [Chris Lloyd-Jones](https://github.com/Sealjay), 
+Huamin Chen, [Marlow Weston](https://github.com/catblade), [Niki Manoledaki](https://github.com/nikimanoledaki), Eun Kyung Lee, [Chen Wang](https://github.com/wangchen615), [Chris Lloyd-Jones](https://github.com/Sealjay),
 [Parul Singh](https://github.com/husky-parul), [Przemysław Perycz](https://github.com/pperycz), [Christopher Cantalupo](https://github.com/cmcantalupo), [Patricia Cahill](https://github.com/patricia-cahill), [Jochen Joswig](https://github.com/by-d-sign), [Emily Fox](https://github.com/thefoxatwork), [Leonard Pahlke](https://github.com/leonardpahlke)
 
 ## Foundations of Sustainable Cloud Systems
@@ -125,17 +125,17 @@ security concerns.
 
 Quantifying embedded carbon emissions is also very challenging as manufactural details (embodied emissions) are not being incorporated into information for holistic quantification by consumers of manufactured technology.
 This is out of the scope of this white paper, however this TAG encourages interested readers to suggest guidance, best practices, methods, and mechanisms to quantify these emissions by filing an issue or pull request on our [repository](https://github.com/cncf/tag-env-sustainability).
-<!-- We may want to put some directions though // +1, would this be guidance/best practice on methods to quantify these emissions or guidance on methods to mitigate these emissions? --> 
+<!-- We may want to put some directions though // +1, would this be guidance/best practice on methods to quantify these emissions or guidance on methods to mitigate these emissions? -->
 
 ### Clouds
 
 #### Challenges in the Public Cloud
-Public cloud providers, such as AWS, Azure, and GCP are often quite restrictive with consumption and emission data, as the providers limit decisions users can make with regard to accessing sustainability-related metrics. 
+Public cloud providers, such as AWS, Azure, and GCP are often quite restrictive with consumption and emission data, as the providers limit decisions users can make with regard to accessing sustainability-related metrics.
 Sustainability-related metrics include data points such as the energy consumption, hardware, electricity source, data center PUE, etc.
 
 Providers do try to keep their day-to-day costs, energy usage, and emissions down, but the functionality exposed to users to can be quite limited.
 This is likely due in part to the shared responsibility model upon which cloud computing is designed - abstracting the operational complexity organizations would otherwise be responsible for in running their own data centers.
-<!--- this statement needs reference: They do not trust their users, as users vary from amateur to experienced. --->  
+<!--- this statement needs reference: They do not trust their users, as users vary from amateur to experienced. --->
 Additionally, the quantification challenges previously identified also contribute heavily to further difficulties in accounting for carbon costs by specific users, as the carbon accounting can take much longer than users have to connect to individual types of jobs.
 The hyperscalers mentioned above offer insight into the carbon emissions of cloud resources through carbon dashboards or APIs.
 Yet, these can be quite limited and/or have a considerable time lag for the carbon emission data to become available within an acceptable timewindow for users to take action on.
@@ -149,7 +149,7 @@ Those that do care about their environmental impact have a hard time connecting 
 
 #### Challenges in the Private Clouds
 These are clouds run by particular companies or universities for use of the members of those companies or universities.
-These clouds are often more trusting environments, as the users are accountable to the administrators or management of the cloud they are running their workloads on. 
+These clouds are often more trusting environments, as the users are accountable to the administrators or management of the cloud they are running their workloads on.
 Due to the special-purposes of private clouds, environmental sustainability, green computing, and accountability of emissions are not in the forefront of design, operation, or even expense, thus contributing to further challenges unique to private cloud.
 These are still yet unknown.
 
@@ -201,7 +201,7 @@ If you know of some that aren't captured here, we would love for you to contribu
 ### Energy Conservation and Carbon Reduction
 
 #### Tuning, Scaling, and Configuration
-At runtime, energy consumed by workloads can be reduced at HW level through DVFS-based scaling, at SW level through runtime parameter tuning and re-configuration, or at the orchestration level through scale-to-zero automation. 
+At runtime, energy consumed by workloads can be reduced at HW level through DVFS-based scaling, at SW level through runtime parameter tuning and re-configuration, or at the orchestration level through scale-to-zero automation.
 
 ### Green System Architecture
 Green HW/SW systems either improve sub-system efficiency or change the way that computation is conducted.
@@ -233,17 +233,17 @@ flowchart TB
 #### Smart Data Centers
 * ECO-Qube is a holistic management system that aims to enhance energy efficiency and cooling performance by orchestrating both hardware and software components in edge computing applications [ECO-Qube](https://eco-qube.eu/)
 * [Patchwork Kilt](https://openuk.uk/patchworkkilt/) - A blueprint for sustainable data centers.
-* [Open Compute Sustainability Project](https://www.opencompute.org/projects/sustainability) - Leveraging the expertise of the OCP community, we offer an open framework and resources for OCP members and data center industry – vendors, suppliers, and end users - to deploy industry best practices that promotes reusability and circularity.  
+* [Open Compute Sustainability Project](https://www.opencompute.org/projects/sustainability) - Leveraging the expertise of the OCP community, we offer an open framework and resources for OCP members and data center industry – vendors, suppliers, and end users - to deploy industry best practices that promotes reusability and circularity.
 
 #### Cooling / BMC
-* :newspaper: :ice_cube: OCP Cooling Telemetry [Improve data center cooling facility efficiency through platform power telemetry](https://www.opencompute.org/documents/ocp-wp-dcf-improve-data-center-cooling-facility-efficiency-through-platform-power-telemetryr1-0-final-update-pdf) <br> 
+* :newspaper: :ice_cube: OCP Cooling Telemetry [Improve data center cooling facility efficiency through platform power telemetry](https://www.opencompute.org/documents/ocp-wp-dcf-improve-data-center-cooling-facility-efficiency-through-platform-power-telemetryr1-0-final-update-pdf) <br>
 Data center operators usually over provision facility capacity to ensure enough buffer to fulfill peak demand.
 Over provisioning brings great pressure to data centers' total cost of ownership (TCO).
 Today, the data center management stack has been widely deployed to monitor data center runtime health status and it gathered tons of data across power, temperature, and resource utilization.
 These data create opportunities to optimize data center efficiency through data intelligences.
-In this paper, we introduced our practices in cloud environments for using power trend prediction to improve cooling efficiency. 
+In this paper, we introduced our practices in cloud environments for using power trend prediction to improve cooling efficiency.
 Meanwhile, this paper discussed some key challenges and design considerations while enabling IT platform data-driven facility control at hyperscale data center, e.g. telemetry collection, messaging mechanism, and management API.
-Effective interoperability among IT devices, facility and management systems is very critical for solution deployment, and the adoption of Open Compute Project design and Redfish API easier system-level integration and reduce deployment costs over different systems and different manufacturers. 
+Effective interoperability among IT devices, facility and management systems is very critical for solution deployment, and the adoption of Open Compute Project design and Redfish API easier system-level integration and reduce deployment costs over different systems and different manufacturers.
 * :ice_cube: BMC Telemetry [Exposes Baseboard Management Controller data in Prometheus format.](https://github.com/gebn/bmc_exporter)
 
 ### Methodologies
@@ -257,7 +257,7 @@ Effective interoperability among IT devices, facility and management systems is 
 
 * :eyes: Open Telemetry [High-quality, ubiquitous, and portable telemetry to enable effective observability](https://opentelemetry.io/)<br>
 A CNCF incubating project designed to create and collect telemetry data from services and software and then forward these to a variety of analysis tools.
-OpenTelemetry integrates with popular libraries and frameworks such as Spring, ASP.NET Core, Express, Quarkus, and others.  
+OpenTelemetry integrates with popular libraries and frameworks such as Spring, ASP.NET Core, Express, Quarkus, and others.
 
 ### Observability Tooling
 
@@ -296,7 +296,7 @@ flowchart TB
 * :eyes: gProfiler [OS code profiling tool to visualize applications' execution sequences and resource usage down to the line of code level](https://docs.gprofiler.io/)<br>
 gProfiler, is a free, self-service, and open source, enabling businesses to improve application performance through continuous profiling, thereby reducing costs and minimizing carbon footprint.
 Granulate users can monitor their carbon emission reduction on the gCenter dashboard, alongside cost and resource reductions, with the CO2 Savings Meter.
-* :eyes: PowerAPI [Python framework for building software-defined power meters](https://github.com/powerapi-ng/)<br> 
+* :eyes: PowerAPI [Python framework for building software-defined power meters](https://github.com/powerapi-ng/)<br>
 PowerAPI is a middleware toolkit for building software-defined power meters.
 Software-defined power meters are configurable software libraries that can estimate the power consumption of software in real time.
 PowerAPI supports the acquisition of raw metrics from a wide diversity of sensors (eg., physical meters, processor interfaces, hardware counters, OS counters) and the delivery of power consumptions via different channels (including file system, network, web, graphical).
@@ -317,7 +317,7 @@ Includes multiple input plugins that help determine energy consumption, e.g. [in
 A rich set of available output plugins makes it easy to integrate with various metrics destinations.
 * :eyes: [Carbon QL](https://github.com/Green-Software-Foundation/carbon-ql) - The intent of this project is to build a single API codenamed carbonQL that you can use to measure your software emissions for every runtime environment.
 * :eyes: [Cloud Carbon Footprint](https://www.cloudcarbonfootprint.org/docs/) <br>
-This application pulls usage data (compute, storage, networking, etc.) from major cloud providers and calculates estimated energy (Watt-Hours) and greenhouse gas emissions expressed as carbon dioxide equivalents (metric tons CO2e). 
+This application pulls usage data (compute, storage, networking, etc.) from major cloud providers and calculates estimated energy (Watt-Hours) and greenhouse gas emissions expressed as carbon dioxide equivalents (metric tons CO2e).
 We display these visualizations in a dashboard for developers, sustainability leaders and other stakeholders in an organization to view and take action. It currently supports AWS, Google Cloud and Microsoft Azure.
 * :eyes: [PowerTOP](https://github.com/fenrus75/powertop) - a Linux tool, which among other things allows you to monitor the power consumption per process running on the Linux machine.
 * :green_book: OSTI [Paper] [Metrics for Evaluating Energy Saving Techniques for Resilient HPC Systems](https://www.osti.gov/servlets/purl/1140455)
@@ -370,7 +370,7 @@ Telemetry Aware Scheduling, a scheduling extension, and the Kubernetes native Ho
 The power metrics used to drive placement and scaling decisions derive from Intel's Running Average Power Limit (RAPL). [collectd](https://collectd.org/) is used to gather the metrics and expose them to Prometheus which makes them available inside the cluster using the Prometheus Adapter.
 * :train: [Intent Driven Orchestration](https://github.com/intel/intent-driven-orchestration) <br>
 This grants a new way to do orchestration by moving from an imperative model to an intent driven model for choosing workload placement.
-In this model, the user expresses their intents in the form of objectives (e.g. as required latency, throughput, or reliability targets) and the orchestration stack itself determines what resources in the infrastructure are required to fulfill the objectives. 
+In this model, the user expresses their intents in the form of objectives (e.g. as required latency, throughput, or reliability targets) and the orchestration stack itself determines what resources in the infrastructure are required to fulfill the objectives.
 This new approach will continue to benefit from community investments in scheduling (determining when & where to place workloads) and be augmented with a continuous running planning loop determining what/how to configure in the system.
 There is already preliminary work being done to leverage this in a power-optimal usage environment.
 * :green_book: Carbon-aware Kubernetes scheduler [A Low Carbon Kubernetes Scheduler](http://ceur-ws.org/Vol-2382/ICT4S2019_paper_28.pdf)
@@ -395,7 +395,7 @@ That’s how CLEVER guarantees a similar QoS for a workload by lowering the freq
 Once the region and node are chosen, administrators and users can further tune the node to minimize the amount of power necessary to run workloads.
 This can reduce power 30% or more per node.
 
-* :musical_note: Node tuning via TuneD on OCP [Manage node-level tuning by orchestrating the tuned daemon](https://docs.openshift.com/container-platform/4.10/scalability_and_performance/using-node-tuning-operator.html) <br> 
+* :musical_note: Node tuning via TuneD on OCP [Manage node-level tuning by orchestrating the tuned daemon](https://docs.openshift.com/container-platform/4.10/scalability_and_performance/using-node-tuning-operator.html) <br>
 The Node Tuning Operator helps you manage node-level tuning by orchestrating the TuneD daemon.
 The majority of high-performance applications require some level of kernel tuning. The Node Tuning Operator provides a unified management interface to users of node-level sysctl's and more flexibility to add custom tuning specified by user needs.
 * :musical_note: Kubernetes Power Manager [Kubernetes Operator designed to expose and utilize Intel specific power management technologies in a Kubernetes Environment](https://github.com/intel/kubernetes-power-manager) <br>
@@ -420,18 +420,18 @@ There are a number of sustainability initiatives ongoing, if we've missed one pl
 
 ### Organizations
 * :honeybee: Green Software Foundation [Building a trusted ecosystem of people, standards, tooling and best practices for green software](https://greensoftware.foundation/) <br>
-  The Green Software Foundation (GSF) exists to change how we build software, [so there are zero harmful environmental effects](https://greensoftware.foundation/articles/theory-of-change-defining-strategy-gsf), a foundation with over 42 member organizations.
+  The Green Software Foundation (GSF) exists to change how we build software, [so there are zero harmful environmental effects](https://greensoftware.foundation/articles/theory-of-change), a foundation with over 42 member organizations.
   Key pillars are Knowledge, Tech Culture, and Tooling; which are delivered through a [standards working group](https://standards.greensoftware.foundation/), an [open source working group](https://opensource.greensoftware.foundation/), a [community working group](https://community.greensoftware.foundation/), and a [policy working group](https://policy.greensoftware.foundation/). <br>
   The GSF has created a [software carbon intensity (SCI)](https://github.com/Green-Software-Foundation/software_carbon_intensity) standard, which has been submitted to ISO (International Standards Organisation) for ratification, to ensure we measure carbon consistently. This standard is being implemented in code through the [Carbon Aware SDK](https://github.com/Green-Software-Foundation/carbon-aware-sdk) (a tool to do more when the energy grid is green, and less when it is dirty), the [Carbon Pipeline](https://github.com/Green-Software-Foundation/Carbon_CI_Pipeline_Tooling) (measuring carbon in the CICD process, and [CarbonQL](https://github.com/Green-Software-Foundation/carbon-ql) - a standardized API for measuring carbon according to the SCI standard.
 * :honeybee: [LF Energy](https://www.lfenergy.org/)<br>
-  LF Energy is an open source foundation focused on the power systems sector, hosted within The Linux Foundation. LF Energy provides a neutral, collaborative community to build the shared digital investments that will transform the world’s relationship to energy.  This organization contains the repositories for the core LF Energy Foundation and many of the hosted projects and working groups. Their landscape can be found [here](https://landscape.lfenergy.org/).  
+  LF Energy is an open source foundation focused on the power systems sector, hosted within The Linux Foundation. LF Energy provides a neutral, collaborative community to build the shared digital investments that will transform the world’s relationship to energy.  This organization contains the repositories for the core LF Energy Foundation and many of the hosted projects and working groups. Their landscape can be found [here](https://landscape.lfenergy.org/).
 * :honeybee: Energy Efficient High Performance Computing Working Group [Encourages implementation of energy conservation measures, energy efficient design in high performance computing (HPC)](https://eehpcwg.llnl.gov/)<br>
-  Mission is to encourage the implementation of energy conservation measures, energy efficient design in high performance computing (HPC), and 
+  Mission is to encourage the implementation of energy conservation measures, energy efficient design in high performance computing (HPC), and
   share ideas.  Can find an extensive collection of papers [here](https://datacenters.lbl.gov/resources?field_focus_areas_tid) that can be
   extrapolated from in terms of patterns to be lifted into the cloud native landscape.
 * :honeybee: [Green Software Training](https://learn.greensoftware.foundation/) <br>
   This initiative will teach you how to build, maintain and run greener applications irrespective of the application domain, industry, organization size or type, programming language, or framework; leading to a [Green Software Certification](https://training.linuxfoundation.org/training/green-software-for-practitioners-lfc131/) backed by the Linux Foundation.
-* :honeybee: [Cloud Carbon Footprint](https://www.cloudcarbonfootprint.org/)<br> 
+* :honeybee: [Cloud Carbon Footprint](https://www.cloudcarbonfootprint.org/)<br>
   Get to know the carbon footprint of your cloud usage - and reduce it.<br>
 Cloud Carbon Footprint is an open source tool that provides visibility and tooling to measure, monitor and reduce your cloud carbon emissions. We use best practice methodologies to convert cloud utilization into estimated energy usage and carbon emissions, producing metrics and carbon savings estimates that can be shared with employees, investors, and other stakeholders.
 * 🐝 [Open Compute Project](https://www.opencompute.org/projects/heat-reuse)<br>
@@ -446,7 +446,7 @@ Cloud Carbon Footprint is an open source tool that provides visibility and tooli
 * :page_facing_up: IEA [Emissions - Global Energy and CO2 Status Report 2019](https://www.iea.org/reports/global-energy-co2-status-report-2019/emissions)
 * :page_facing_up: European Environment Agency [EU Greenhouse Emission Intensity](https://www.eea.europa.eu/ims/greenhouse-gas-emission-intensity-of-1)
 * :page_facing_up: electricityMap's [real-time CO2 emission data](https://app.electricitymap.org)
-* [SCI Reporting](https://github.com/Green-Software-Foundation/sci-reporting) - Creating the infrastructure, and processes to store, host, and publicly report SCI scores, and other related reporting requirements within the SCI specification. 
+* [SCI Reporting](https://github.com/Green-Software-Foundation/sci-reporting) - Creating the infrastructure, and processes to store, host, and publicly report SCI scores, and other related reporting requirements within the SCI specification.
 * :page_facing_up: WattTime API [Provides insight into a electricity grid’s marginal emissions rate](https://www.watttime.org/api-documentation/#introduction)
 
 ### Net Zero / Carbon Neutrality

--- a/website/package.json
+++ b/website/package.json
@@ -1,5 +1,8 @@
 {
   "scripts": {
+    "__check:links": "npx --no -p htmltest-bin htmltest",
+    "_check:links": "npm run __check:links -- --log-level 1",
+    "_check:links:internal": "npm run __check:links -- --skip-external",
     "_get:no": "echo SKIPPING get operation",
     "_get:submodule": "set -x && git submodule update --init --recursive ${DEPTH:- --depth 1}",
     "_hugo:dev": "hugo --cleanDestinationDir -e dev -DFE",
@@ -9,23 +12,28 @@
     "build:preview": "set -x && npm run _hugo:dev -- --minify --baseURL \"${DEPLOY_PRIME_URL:-/}\"",
     "build:production": "hugo --cleanDestinationDir --minify",
     "build": "npm run _hugo:dev",
+    "check:links": "npm run _check:links",
     "get:submodule": "npm run _get:${GET:-submodule}",
+    "post__check:links": "npx prettier --write tmp/.htmltest/refcache.json",
     "postget:submodule": "git submodule",
     "prebuild:preview": "npm run _prebuild",
     "prebuild:production": "npm run _prebuild",
     "prebuild": "npm run _prebuild",
+    "precheck:links": "npm run build",
     "prepare": "npm run get:submodule",
     "preserve:dev": "npm run _prebuild",
     "preserve": "npm run _prebuild",
     "serve:dev": "npm run _serve:dev",
     "serve": "npm run _serve:hugo",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "npm run check:links"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.0",
+    "htmltest-bin": "github:chalin/htmltest-bin#semver:0.17.0",
     "hugo-extended": "0.104.3",
     "postcss": "^8.3.7",
-    "postcss-cli": "^9.0.2"
+    "postcss-cli": "^9.0.2",
+    "prettier": "^3.0.1"
   },
   "enginesComment": "Ensure that engines.node stays consistent with .nvmrc",
   "engines": {

--- a/website/tmp/.htmltest/refcache.json
+++ b/website/tmp/.htmltest/refcache.json
@@ -1,0 +1,702 @@
+{
+  "http://ceur-ws.org/Vol-2382/ICT4S2019_paper_28.pdf": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T17:06:51.72661-04:00"
+  },
+  "http://cncf.io": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T17:08:20.979014-04:00"
+  },
+  "http://github.com/AntonioDiTuri": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:05:29.950264-04:00"
+  },
+  "http://github.com/cncf/tag-env-sustainability": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:02:58.713928-04:00"
+  },
+  "http://github.com/david-m-m": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:05:24.535885-04:00"
+  },
+  "http://github.com/eduardoriveror": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:05:07.725448-04:00"
+  },
+  "http://github.com/guidemetothemoon": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:05:13.405812-04:00"
+  },
+  "http://github.com/nikimanoledaki": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:05:19.053936-04:00"
+  },
+  "http://tag-env-sustainability.cncf.io": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T17:02:48.224542-04:00"
+  },
+  "https://app.electricitymap.org": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:08:05.138223-04:00"
+  },
+  "https://app.electricitymaps.com/map": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:01:38.545525-04:00"
+  },
+  "https://bit.ly/cncf-tag-env-meeting-notes": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:53:22.744922-04:00"
+  },
+  "https://cdn.jsdelivr.net/npm/mermaid@8.8.1/dist/mermaid.min.js": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T16:54:53.164032-04:00"
+  },
+  "https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:54:42.99665-04:00"
+  },
+  "https://ceur-ws.org/Vol-2382/ICT4S2019_paper_28.pdf": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T17:32:03.652847-04:00"
+  },
+  "https://cloud-native.slack.com/archives/C03F270PDU6": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:52:21.736816-04:00"
+  },
+  "https://cmp.osano.com/16A0DbT9yDNIaQkvZ/c3494b1e-ff3a-436f-978d-842e9a0bed27/osano.js": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T16:51:50.297364-04:00"
+  },
+  "https://code.jquery.com/jquery-3.5.1.min.js": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T16:51:55.38649-04:00"
+  },
+  "https://collectd.org/": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:58:56.909788-04:00"
+  },
+  "https://community.cncf.io/chapters/": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:08:26.45367-04:00"
+  },
+  "https://community.greensoftware.foundation/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T17:00:26.998499-04:00"
+  },
+  "https://datacenters.lbl.gov/resources": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:07:41.354301-04:00"
+  },
+  "https://dateful.com/convert/utc": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:52:48.450785-04:00"
+  },
+  "https://docs.google.com/document/d/1s28lqqc3IBAMw4T7n13zfyAuUEEc3I4_xhPxCLA4_dk/edit": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:08:47.224769-04:00"
+  },
+  "https://docs.google.com/document/d/1s28lqqc3IBAMw4T7n13zfyAuUEEc3I4_xhPxCLA4_dk/edit#heading=h.19phjl5j6fdw": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:08:52.56059-04:00"
+  },
+  "https://docs.gprofiler.io/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T16:57:30.188214-04:00"
+  },
+  "https://docs.green-coding.berlin/": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:57:57.382838-04:00"
+  },
+  "https://docs.openshift.com/container-platform/4.10/scalability_and_performance/using-node-tuning-operator.html": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T17:07:02.019596-04:00"
+  },
+  "https://drive.google.com/drive/folders/1pdBQTxlpvDr0QFIuIpjfERau1IQNfdaX": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:09:27.080525-04:00"
+  },
+  "https://eco-qube.eu/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T16:56:30.258397-04:00"
+  },
+  "https://eehpcwg.llnl.gov/": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:00:56.195142-04:00"
+  },
+  "https://en.wikipedia.org/wiki/Run-time_estimation_of_system_and_sub-system_level_power_consumption": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:05:51.517641-04:00"
+  },
+  "https://events.linuxfoundation.org/open-source-summit-north-america/about/sustainabilitycon/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T17:01:12.388281-04:00"
+  },
+  "https://events.linuxfoundation.org/open-source-summit-north-america/program/schedule/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T17:40:19.761216-04:00"
+  },
+  "https://geopm.github.io": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T17:07:07.072459-04:00"
+  },
+  "https://geopm.github.io/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T16:59:50.251417-04:00"
+  },
+  "https://ghgprotocol.org/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T16:55:48.813275-04:00"
+  },
+  "https://github.com/Green-Software-Foundation/Carbon_CI_Pipeline_Tooling": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:07:23.716558-04:00"
+  },
+  "https://github.com/Green-Software-Foundation/carbon-aware-sdk": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:58:45.907106-04:00"
+  },
+  "https://github.com/Green-Software-Foundation/carbon-ci": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:00:37.571315-04:00"
+  },
+  "https://github.com/Green-Software-Foundation/carbon-ql": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:58:24.40469-04:00"
+  },
+  "https://github.com/Green-Software-Foundation/sci": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:56:59.110734-04:00"
+  },
+  "https://github.com/Green-Software-Foundation/sci-reporting": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:01:43.999696-04:00"
+  },
+  "https://github.com/Green-Software-Foundation/software_carbon_intensity": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:07:18.098697-04:00"
+  },
+  "https://github.com/Sealjay": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:55:10.113952-04:00"
+  },
+  "https://github.com/by-d-sign": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:55:37.928648-04:00"
+  },
+  "https://github.com/caradelia": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:53:55.311832-04:00"
+  },
+  "https://github.com/catblade": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:53:44.436766-04:00"
+  },
+  "https://github.com/cmcantalupo": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:55:26.7957-04:00"
+  },
+  "https://github.com/cncf": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:54:11.998882-04:00"
+  },
+  "https://github.com/cncf/tag-env-sustainability": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:52:06.107048-04:00"
+  },
+  "https://github.com/cncf/tag-env-sustainability/blob/main/charter.md": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T16:52:11.337086-04:00"
+  },
+  "https://github.com/cncf/tag-env-sustainability/commit/2201e6e5f3ab0c1ed71d75c8fa042536f03b041a": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:09:53.735048-04:00"
+  },
+  "https://github.com/cncf/tag-env-sustainability/commit/38cb8316e393d7f1ce3eb53d86e0bb642992a3f5": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:09:32.3954-04:00"
+  },
+  "https://github.com/cncf/tag-env-sustainability/commit/5d9eedce7285279057c2424c7ad730d6f75a4586": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:09:43.049563-04:00"
+  },
+  "https://github.com/cncf/tag-env-sustainability/commit/5f8b4d8ff783e94372ac985788b1c95eb8610241": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:10:16.816135-04:00"
+  },
+  "https://github.com/cncf/tag-env-sustainability/commit/b3a79ac74e7fbd8ae194c8e84fbf77884fb24f4c": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:02:22.181724-04:00"
+  },
+  "https://github.com/cncf/tag-env-sustainability/issues": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:05:35.80208-04:00"
+  },
+  "https://github.com/cncf/tag-env-sustainability/issues/134": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:09:08.4179-04:00"
+  },
+  "https://github.com/cncf/tag-env-sustainability/issues/95": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:09:16.528072-04:00"
+  },
+  "https://github.com/cncf/tag-env-sustainability/issues/new": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:52:00.634219-04:00"
+  },
+  "https://github.com/cncf/tag-env-sustainability/milestone/3": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:09:21.840684-04:00"
+  },
+  "https://github.com/cncf/tag-env-sustainability/tree/main/surveys": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T16:52:43.18819-04:00"
+  },
+  "https://github.com/fenrus75/powertop": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:58:34.993821-04:00"
+  },
+  "https://github.com/gebn/bmc_exporter": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:06:10.143371-04:00"
+  },
+  "https://github.com/geopm/geopm": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:59:45.129664-04:00"
+  },
+  "https://github.com/geopm/geopm/tree/cloud#experimental-branch": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:59:55.842649-04:00"
+  },
+  "https://github.com/geopm/geopm/tree/cloud/k8": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T17:00:06.580329-04:00"
+  },
+  "https://github.com/geopm/geopm/tree/cloud/service#kubernetes-support": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T17:00:01.306948-04:00"
+  },
+  "https://github.com/greensoftwarelab/Energy-Languages": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:02:16.629794-04:00"
+  },
+  "https://github.com/hubblo-org/scaphandre": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:57:51.98501-04:00"
+  },
+  "https://github.com/husky-parul": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:55:15.737185-04:00"
+  },
+  "https://github.com/influxdata/telegraf": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:58:02.84392-04:00"
+  },
+  "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/intel_powerstat": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T17:06:25.372738-04:00"
+  },
+  "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/ipmi_sensor": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T17:06:30.605452-04:00"
+  },
+  "https://github.com/influxdata/telegraf/tree/master/plugins/inputs/redfish": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T17:06:35.814922-04:00"
+  },
+  "https://github.com/intel/intent-driven-orchestration": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:59:02.279088-04:00"
+  },
+  "https://github.com/intel/kubernetes-power-manager": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:59:39.655722-04:00"
+  },
+  "https://github.com/intel/platform-aware-scheduling/tree/master/telemetry-aware-scheduling/docs/power": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T16:58:51.156741-04:00"
+  },
+  "https://github.com/leonardpahlke": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:53:38.898896-04:00"
+  },
+  "https://github.com/mkorbi": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:53:49.937662-04:00"
+  },
+  "https://github.com/nikimanoledaki": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:54:58.871944-04:00"
+  },
+  "https://github.com/openshift/predictive-vpa-recommenders": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:59:18.39048-04:00"
+  },
+  "https://github.com/patricia-cahill": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:55:32.384214-04:00"
+  },
+  "https://github.com/powerapi-ng/": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:57:35.645061-04:00"
+  },
+  "https://github.com/pperycz": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:55:21.180047-04:00"
+  },
+  "https://github.com/sustainable-computing-io/clever": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:59:23.88771-04:00"
+  },
+  "https://github.com/sustainable-computing-io/kepler": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:57:41.066256-04:00"
+  },
+  "https://github.com/sustainable-computing-io/kepler-model-server": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:57:46.527295-04:00"
+  },
+  "https://github.com/thefoxatwork": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:55:43.496381-04:00"
+  },
+  "https://github.com/wangchen615": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:55:04.430833-04:00"
+  },
+  "https://gosupercritical.com/": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:02:11.184083-04:00"
+  },
+  "https://greensoftware.foundation/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T17:00:11.707236-04:00"
+  },
+  "https://greensoftware.foundation/articles/theory-of-change": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T17:43:30.142844-04:00"
+  },
+  "https://hal.inria.fr/hal-03275286/document": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T17:06:04.726666-04:00"
+  },
+  "https://haslab.github.io/SAFER/scp21.pdf": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T16:56:09.167217-04:00"
+  },
+  "https://icalfilter.com/j9732u68l2": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:53:05.910625-04:00"
+  },
+  "https://inria.hal.science/hal-03275286/document": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T16:56:19.738012-04:00"
+  },
+  "https://keda.sh/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T16:59:29.027388-04:00"
+  },
+  "https://landscape.lfenergy.org/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T17:00:49.381038-04:00"
+  },
+  "https://learn.greensoftware.foundation/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T17:01:01.282156-04:00"
+  },
+  "https://learn.greensoftware.foundation/assets/images/06_energy_proportionality_updated-a6941b6c0d261511e74dc2217062373c.png": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T16:55:58.946335-04:00"
+  },
+  "https://learn.greensoftware.foundation/energy-efficiency#energy-proportionality": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T17:05:46.219213-04:00"
+  },
+  "https://learn.greensoftware.foundation/energy-efficiency/#energy-proportionality": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T16:55:53.887024-04:00"
+  },
+  "https://lfenergy.org/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T17:00:43.412765-04:00"
+  },
+  "https://lists.cncf.io/g/cncf-tag-env-sustainability/topics": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:52:37.99897-04:00"
+  },
+  "https://opensource.greensoftware.foundation/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T17:00:21.896496-04:00"
+  },
+  "https://opentelemetry.io/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T16:57:24.556546-04:00"
+  },
+  "https://openuk.uk/patchworkkilt/": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:56:36.199301-04:00"
+  },
+  "https://patterns.greensoftware.foundation/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T16:57:04.17991-04:00"
+  },
+  "https://policy.greensoftware.foundation/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T17:00:32.10112-04:00"
+  },
+  "https://redfish.dmtf.org/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T16:58:18.943555-04:00"
+  },
+  "https://sched.co/1HyPf": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:03:56.667983-04:00"
+  },
+  "https://sched.co/1HyPo": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:03:35.509613-04:00"
+  },
+  "https://sched.co/1HyW9": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:04:17.899061-04:00"
+  },
+  "https://sched.co/1HyWC": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:03:09.244873-04:00"
+  },
+  "https://sched.co/1HyXM": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:03:24.895881-04:00"
+  },
+  "https://sched.co/1HyYK": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:04:51.83547-04:00"
+  },
+  "https://sched.co/1HybW": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:04:28.509703-04:00"
+  },
+  "https://sched.co/1Hybr": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:04:41.162588-04:00"
+  },
+  "https://sched.co/1Hycj": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:03:46.062478-04:00"
+  },
+  "https://sched.co/1Hzd3": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:04:07.204332-04:00"
+  },
+  "https://sched.co/1JWOX": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:09:48.421396-04:00"
+  },
+  "https://slack.cncf.io/": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:52:32.530009-04:00"
+  },
+  "https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:54:48.078322-04:00"
+  },
+  "https://standards.greensoftware.foundation/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T17:00:16.804118-04:00"
+  },
+  "https://support.google.com/calendar/answer/37100": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:53:11.114223-04:00"
+  },
+  "https://tag-env-sustainability.cncf.io/about/index.xml": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T17:02:27.578111-04:00"
+  },
+  "https://tag-env-sustainability.cncf.io/blog/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T17:02:32.74729-04:00"
+  },
+  "https://tag-env-sustainability.cncf.io/blog/index.xml": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T17:02:37.960602-04:00"
+  },
+  "https://tag-env-sustainability.cncf.io/cloud-native-sustainability-week/index.xml": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T17:08:10.60928-04:00"
+  },
+  "https://tag-env-sustainability.cncf.io/events/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T16:52:16.427483-04:00"
+  },
+  "https://tag-env-sustainability.cncf.io/events/index.xml": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T17:09:37.736997-04:00"
+  },
+  "https://tag-env-sustainability.cncf.io/index.xml": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T16:51:45.230549-04:00"
+  },
+  "https://tag-env-sustainability.cncf.io/landscape/index.xml": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T17:05:41.101591-04:00"
+  },
+  "https://tockify.com/cncf.public.events/detail/598/1683747900000": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:10:11.392175-04:00"
+  },
+  "https://tockify.com/cncf.public.events/monthly": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:52:58.878645-04:00"
+  },
+  "https://training.linuxfoundation.org/training/green-software-for-practitioners-lfc131/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T17:07:48.225891-04:00"
+  },
+  "https://wetransfer.com/blog/story/breaking-the-climate-neutral-barrier/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T17:02:00.418759-04:00"
+  },
+  "https://www.aboutamazon.com/news/sustainability/cloud-computing-pioneers-new-focus-is-on-sustainability-transformation": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:02:05.946741-04:00"
+  },
+  "https://www.bevy.com": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T17:32:34.251027-04:00"
+  },
+  "https://www.cam.ac.uk/research/news/can-federated-learning-save-the-world": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T16:56:25.142409-04:00"
+  },
+  "https://www.cloudcarbonfootprint.org/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T17:01:06.420978-04:00"
+  },
+  "https://www.cloudcarbonfootprint.org/docs/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T16:58:29.625487-04:00"
+  },
+  "https://www.cncf.io/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T16:54:00.588816-04:00"
+  },
+  "https://www.cncf.io/all-cncf/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T16:54:05.643909-04:00"
+  },
+  "https://www.cncf.io/calendar/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T16:52:53.646367-04:00"
+  },
+  "https://www.eea.europa.eu/ims/greenhouse-gas-emission-intensity-of-1": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:01:33.339046-04:00"
+  },
+  "https://www.enviroinfo2023.eu/": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:01:21.20108-04:00"
+  },
+  "https://www.facebook.com/CloudNativeComputingFoundation/": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:54:32.86278-04:00"
+  },
+  "https://www.flickr.com/photos/143247548@N03/albums": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:54:27.713828-04:00"
+  },
+  "https://www.iea.org/reports/global-energy-co2-status-report-2019/emissions": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:01:27.342898-04:00"
+  },
+  "https://www.instagram.com/humans.of.cloudnative/": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:54:17.27155-04:00"
+  },
+  "https://www.lfenergy.org/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T17:07:34.158107-04:00"
+  },
+  "https://www.opencompute.org/documents/ocp-wp-dcf-improve-data-center-cooling-facility-efficiency-through-platform-power-telemetryr1-0-final-update-pdf": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:56:48.613352-04:00"
+  },
+  "https://www.opencompute.org/projects/heat-reuse": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:07:54.782573-04:00"
+  },
+  "https://www.opencompute.org/projects/sustainability": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:56:42.638175-04:00"
+  },
+  "https://www.osti.gov/biblio/1140455": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:58:40.526744-04:00"
+  },
+  "https://www.osti.gov/servlets/purl/1140455": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T17:06:41.077635-04:00"
+  },
+  "https://www.theclimatepledge.com/": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T17:01:55.014698-04:00"
+  },
+  "https://www.twitch.tv/cloudnativefdn": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:54:37.932838-04:00"
+  },
+  "https://www.watttime.org/api-documentation/#introduction": {
+    "StatusCode": 206,
+    "LastSeen": "2023-08-08T17:01:49.574968-04:00"
+  },
+  "https://www.youtube.com/@CNCFEnvTAG/playlists": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:53:33.256763-04:00"
+  },
+  "https://www.youtube.com/c/cloudnativefdn": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:54:22.408482-04:00"
+  },
+  "https://youtu.be/6tmc-2BqV50": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:04:46.39762-04:00"
+  },
+  "https://youtu.be/E02sFT5wqEw": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:03:30.1213-04:00"
+  },
+  "https://youtu.be/QvSCbdOaUn0": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:04:57.17663-04:00"
+  },
+  "https://youtu.be/VCIdFHhp4No": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:04:12.414365-04:00"
+  },
+  "https://youtu.be/Wn0S6CTXGS4": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:03:19.516351-04:00"
+  },
+  "https://youtu.be/_SqebJmYteQ": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:03:51.262066-04:00"
+  },
+  "https://youtu.be/jsBSNCuSI74": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:04:35.714651-04:00"
+  },
+  "https://youtu.be/ppe0ptZEcvw": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:04:23.096488-04:00"
+  },
+  "https://youtu.be/qRnhAex9aZI": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:04:01.873234-04:00"
+  },
+  "https://youtu.be/s7K7QkhWnFU": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T17:03:40.702035-04:00"
+  },
+  "https://zoom.us/my/cncftagenvsustainability": {
+    "StatusCode": 200,
+    "LastSeen": "2023-08-08T16:53:28.113758-04:00"
+  }
+}


### PR DESCRIPTION
- Contributes to fixing #164
- Adds a link checker
- Adds scripts in support of checking local and external links
  - In particular, you can build the site and check links using: `npm run test`
- Fixes **all broken links except** from the one mentioned in #164, which is currently ignored until **someone can suggest a replacement**
  - The Korean language landscape page had several broken links but only because underscore characters in URLs were being (unnecessarily) escaped.
- Note that the link checker uses a cache for external links, so link checking is quick (< 100ms on my machine)
- Some of the files are best reviewed by ignoring whitespace changes (my editor trims off trailing whitespace)