### PR TITLE
fix: updated broken links

### DIFF
--- a/website/.htmltest.yml
+++ b/website/.htmltest.yml
@@ -11,7 +11,3 @@ IgnoreURLs: # list of regexs of paths or URLs to be ignored
   # Ignore Docsy-generated GitHub links:
   - ^https?://github\.com/.*?/.*?/(new|edit)/ # view-page, edit-source etc
   - ^https://github.com/cncf/tag-env-sustainability/commit/ # last mod
-
-  # TODO: fix me! Links that no longer exist
-  - ^https://sci-data.greensoftware.foundation/
-    # Should this link to https://greensoftware.foundation/articles/software-carbon-intensity-sci-specification-project?

--- a/website/content/about/SustainabilityUseCasesAndLandscape2023.ko.md
+++ b/website/content/about/SustainabilityUseCasesAndLandscape2023.ko.md
@@ -185,7 +185,7 @@ flowchart TB
 
 [그린 소프트웨어 패턴](https://patterns.greensoftware.foundation/) - 그린 소프트웨어 재단에서 다양한 범주에 걸쳐 검토하고 선별한 소프트웨어 패턴의 온라인 오픈 소스 데이터베이스입니다.
 
-[SCI 지침](https://sci-data.greensoftware.foundation/)- SCI 지침 프로젝트는 SCI 계산의 핵심 구성 요소인 에너지, 탄소 집약도, 구체화된 배출량 및 기능 단위값을 계산하는 데 사용할 수 있는 다양한 방법론을 이해하는 방법에 대한 다양한 접근 방식을 자세히 설명합니다.
+[SCI 지침](https://sci-guide.greensoftware.foundation)- SCI 지침 프로젝트는 SCI 계산의 핵심 구성 요소인 에너지, 탄소 집약도, 구체화된 배출량 및 기능 단위값을 계산하는 데 사용할 수 있는 다양한 방법론을 이해하는 방법에 대한 다양한 접근 방식을 자세히 설명합니다.
 
 런타임(Runtime) - 시스템 전력 소비량 추정 런타임을 통해 [시스템 및 하위 시스템 수준의 전력 소비량에 대한 런타임 예측](https://en.wikipedia.org/wiki/Run-time_estimation_of_system_and_sub-system_level_power_consumption)
 

--- a/website/content/landscape/_index.md
+++ b/website/content/landscape/_index.md
@@ -275,7 +275,7 @@ Effective interoperability among IT devices, facility and management systems is 
 
 * [Software Carbon Intensity (SCI) Standard](https://github.com/Green-Software-Foundation/sci) - A specification that describes how to calculate the carbon intensity of software applications.
 * [Green Software Patterns](https://patterns.greensoftware.foundation/) - An online open-source database of software patterns reviewed and curated by the Green Software Foundation across a wide range of categories.
-* [SCI Guidance](https://sci-data.greensoftware.foundation/) - The SCI Guidance project details various approaches on how to understand the different methodologies that are available for calculating energy, carbon intensity, embodied emissions, and functional unit values which are the core components of the SCI calculation.
+* [SCI Guidance](https://sci-guide.greensoftware.foundation) - The SCI Guidance project details various approaches on how to understand the different methodologies that are available for calculating energy, carbon intensity, embodied emissions, and functional unit values which are the core components of the SCI calculation.
 * Runtime system power consumption estimate [Run-time estimation of system and sub-system level power consumption](https://en.wikipedia.org/wiki/Run-time_estimation_of_system_and_sub-system_level_power_consumption)
 
 #### Observability Methodologies


### PR DESCRIPTION
Updated broken links to SCI guidance to valid ones and cleaned up linter warning.
Closes #164 