### PR TITLE
fix unique issue template names

### DIFF
--- a/.github/ISSUE_TEMPLATE/project-suggestion.md
+++ b/.github/ISSUE_TEMPLATE/project-suggestion.md
@@ -1,7 +1,7 @@
 ---
 name: Project Proposal / Suggestion
 about: Idea for a new project that will improve or enhance the TAG Environmental Sustainability (If you want to implement the idea personally, name it "Proposal" if NOT call it "Suggestion").
-title: "[Project Proposal / Suggestion] some descriptive title"
+title: "[PROEJCT PROPOSAL / SUGGESTION] some descriptive title"
 labels: "triage-required"
 assignees: ''
 ---

--- a/.github/ISSUE_TEMPLATE/project-tracking.md
+++ b/.github/ISSUE_TEMPLATE/project-tracking.md
@@ -1,8 +1,8 @@
 ---
-name: Project Proposal / Suggestion
-about: Idea for a new project that will improve or enhance the TAG Environmental Sustainability (If you want to implement the idea personally, name it "Proposal" if NOT call it "Suggestion").
-title: "[Project Proposal / Suggestion] some descriptive title"
-labels: "triage-required"
+name: Project Tracking
+about: Please use this template only if your project proposal / suggestion was accepted. This template is used to track the ongoing project progress.
+title: "[PROJECT TRACKING] some descriptive title"
+labels: "tracking"
 assignees: ''
 
 ---


### PR DESCRIPTION
this PR fixes the issue template names for added in https://github.com/cncf/tag-env-sustainability/commit/3fdae03ba87e3388be9115ac59e36a9b065fe760. In the commit `project-suggestion.md` & `project-tracking.md` use the same name which is not allowed.