### PR TITLE
Fix Weighting for Events and Adjust EU KubeCon Talks

### DIFF
--- a/website/content/en/events/2023-Kubecon-na.md
+++ b/website/content/en/events/2023-Kubecon-na.md
@@ -1,6 +1,7 @@
 ---
 title: KubeCon + CloudNativeCon NA 2023
 description: TAG Environmental Sustainability presence at Cloud Native Computing Foundation’s flagship conference in Chicago, USA from 6-9 November, 2023.
+weight: 2
 ---
 
 The Cloud Native Computing Foundation’s flagship conference gathers adopters and technologists from leading open source and cloud native communities for the second time in 2023. This time KubeCon+CloudNativeCon event takes place in the windy city of Chicago, USA from 6-9 November, 2023. Both us from the TAG will be delivering a few sessions on-site, and there will be multiple sustainability-related sessions from other community members that we would like to highlight here!

--- a/website/content/en/events/2023-Kubecon-na.md
+++ b/website/content/en/events/2023-Kubecon-na.md
@@ -1,7 +1,7 @@
 ---
 title: KubeCon + CloudNativeCon NA 2023
 description: TAG Environmental Sustainability presence at Cloud Native Computing Foundation’s flagship conference in Chicago, USA from 6-9 November, 2023.
-weight: 2
+weight: 96
 ---
 
 The Cloud Native Computing Foundation’s flagship conference gathers adopters and technologists from leading open source and cloud native communities for the second time in 2023. This time KubeCon+CloudNativeCon event takes place in the windy city of Chicago, USA from 6-9 November, 2023. Both us from the TAG will be delivering a few sessions on-site, and there will be multiple sustainability-related sessions from other community members that we would like to highlight here!

--- a/website/content/en/events/2023-cloud-native-sustainability-week.md
+++ b/website/content/en/events/2023-cloud-native-sustainability-week.md
@@ -3,7 +3,7 @@ title: CNCF Cloud Native Sustainability Week
 linkTitle: Cloud Native Sustainability Week
 exclude_search: true
 description: Cloud Native Sustainability Week is a global event where the CNCF community organizes local meetings around the theme of Cloud Native Sustainability. The Cloud Native Sustainability Week will take place in the second week of October 2023.
-weight: 3
+weight: 97
 slug: cloud-native-sustainability-week
 aliases:
   - /cloud-native-sustainability-week

--- a/website/content/en/events/2023-cloud-native-sustainability-week.md
+++ b/website/content/en/events/2023-cloud-native-sustainability-week.md
@@ -3,8 +3,9 @@ title: CNCF Cloud Native Sustainability Week
 linkTitle: Cloud Native Sustainability Week
 exclude_search: true
 description: Cloud Native Sustainability Week is a global event where the CNCF community organizes local meetings around the theme of Cloud Native Sustainability. The Cloud Native Sustainability Week will take place in the second week of October 2023.
+weight: 3
 slug: cloud-native-sustainability-week
-aliases: 
+aliases:
   - /cloud-native-sustainability-week
 ---
 

--- a/website/content/en/events/2023-kubecon-eu.md
+++ b/website/content/en/events/2023-kubecon-eu.md
@@ -1,7 +1,7 @@
 ---
 title: Kubecon CloudNativeCon EU 2023
 description: TAG Environmental Sustainability presence at Cloud Native Computing Foundation’s flagship conference in Amsterdam, The Netherlands from 18-21 April, 2023.
-weight: 5
+weight: 99
 ---
 
 The Cloud Native Computing Foundation’s flagship conference gathers adopters and technologists from leading open source and cloud native communities in Amsterdam, The Netherlands from 18-21 April, 2023.

--- a/website/content/en/events/2023-kubecon-eu.md
+++ b/website/content/en/events/2023-kubecon-eu.md
@@ -1,6 +1,7 @@
 ---
 title: Kubecon CloudNativeCon EU 2023
 description: TAG Environmental Sustainability presence at Cloud Native Computing Foundation’s flagship conference in Amsterdam, The Netherlands from 18-21 April, 2023.
+weight: 5
 ---
 
 The Cloud Native Computing Foundation’s flagship conference gathers adopters and technologists from leading open source and cloud native communities in Amsterdam, The Netherlands from 18-21 April, 2023.

--- a/website/content/en/events/2023-oss-na.md
+++ b/website/content/en/events/2023-oss-na.md
@@ -1,7 +1,7 @@
 ---
 title: Open Source Summit NA 2023
 description: TAG Environmental Sustainability presence at the Linux Foundation’s flagship conference in Vancouver, British Columbia from 10-12 May, 2023.
-weight: 4
+weight: 98
 ---
 
 Level up your open source knowledge with access to 15 micro-conferences, including SustainabilityCOn, and 300+ sessions. Join the ultimate gathering of open source innovators to learn, network and collaborate in Vancouver, British Columbia from 10-12 May, 2023.

--- a/website/content/en/events/2023-oss-na.md
+++ b/website/content/en/events/2023-oss-na.md
@@ -1,7 +1,7 @@
 ---
 title: Open Source Summit NA 2023
 description: TAG Environmental Sustainability presence at the Linux Foundation’s flagship conference in Vancouver, British Columbia from 10-12 May, 2023.
-weight: 2
+weight: 4
 ---
 
 Level up your open source knowledge with access to 15 micro-conferences, including SustainabilityCOn, and 300+ sessions. Join the ultimate gathering of open source innovators to learn, network and collaborate in Vancouver, British Columbia from 10-12 May, 2023.

--- a/website/content/en/events/2024-kubecon-eu.md
+++ b/website/content/en/events/2024-kubecon-eu.md
@@ -23,17 +23,9 @@ In tech, sustainability is not just an ideal but a pressing technical challenge,
 
 ### Tuesday 19th of March
 
-10:25 - 10:50 CET
-
-* [Panel: Argo for ML: Achieving Scalability and User Experience](https://sched.co/1YFeX)
-
 10:30 - 10:37 CET
 
 * [Sustainable Computing: Measuring Application Energy Consumption in Kubernetes Environments with Kepler | Project Lightning Talk](https://sched.co/1aQWg)
-
-11:40 - 12:15 CET
-
-* [Panel: A Front Row Seat to Backstage Adoption](https://sched.co/1YFfz)
 
 17:35 - 17:40 CET
 

--- a/website/content/en/events/2024-kubecon-eu.md
+++ b/website/content/en/events/2024-kubecon-eu.md
@@ -1,7 +1,7 @@
 ---
 title: Kubecon + CloudNativeCon EU 2024
 description: TAG Environmental Sustainability presence at Cloud Native Computing Foundation’s flagship conference in Paris, France from 19-22 March, 2024.
-weight: 1
+weight: 95
 ---
 
 The Cloud Native Computing Foundation’s flagship conference gathers adopters and technologists from leading open source and cloud native communities in Paris, France from 19-22 March 2024.

--- a/website/content/en/events/2024-kubecon-eu.md
+++ b/website/content/en/events/2024-kubecon-eu.md
@@ -1,6 +1,7 @@
 ---
 title: Kubecon + CloudNativeCon EU 2024
 description: TAG Environmental Sustainability presence at Cloud Native Computing Foundation’s flagship conference in Paris, France from 19-22 March, 2024.
+weight: 1
 ---
 
 The Cloud Native Computing Foundation’s flagship conference gathers adopters and technologists from leading open source and cloud native communities in Paris, France from 19-22 March 2024.


### PR DESCRIPTION
Some of the KubeCon EU talks may have been picked up by the green scraper due to the speakers working for energy companies. Having reviewed these specific talks I don't think they will discuss environmental sustainability.

I have also adjusted the weighting of the events so that they are in order and KubeCon 2024 shows first. When there is more time we can potentially see if we can separate into "Past" and "Upcoming" events.