### PR TITLE
Updated access management document with 1Password information

### DIFF
--- a/governance/README.md
+++ b/governance/README.md
@@ -1,10 +1,11 @@
 # Governance
 
-Environmental Sustainability Working Group is a CNCF Working Group and reports to the Technical Oversight Committee (TOC).
+Environmental Sustainability TAG is a CNCF Technical Advisory Group and reports to the Technical Oversight Committee (TOC).
 
 * [Charter](../charter.md) - mission and scope
-* [Roles](roles.md) - the work of the group is facilitated by Chairs, Technical Leads, and active group contributors
+* [Roles](roles.md) - the work of the TAG is facilitated by Chairs, Technical Leads, and active group contributors
 * [Process](process.md) - how projects are proposed and work is tracked
 * Writing [paper process](paper-process.md) - how to proceed if the proposed project include paper
 * [Presentations](presentations.md)
 * [Communication](communication-channels.md) - how to create new TAG ENV communication channels
+* [Access and secrets management](access-management.md) - how TAG ENV secrets are managed, how to request access, how to add changes to the TAG ENV GitHub repository

--- a/governance/access-management.md
+++ b/governance/access-management.md
@@ -1,4 +1,18 @@
-# Github access permissions and administration
+# Access and secrets management in the TAG ENV
+
+TAG ENV, including working groups and projects, has a collection of secrets that are used for things like social media accounts, infrastructure access, API keys, etc. All of these secrets are stored securely in a dedicated, open source version of 1Password vault. Information regarding access and recovery of the 1Password accound and underlying vaults is stored in a private Google drive folder that's only accessible by the TAG ENV lead team.
+
+## Adding/Requesting access to a secret stored in 1Password
+
+If you need to add a new secret to 1Password or get access to a specific secret stored in a 1Password vault, please request one of the TAG, Working Group or Project leads to add it, or create a GitHub issue to ask for assistance. If you need to add a secret, **PLEASE DON'T ADD THE SECRET VALUE IN PLAINTEXT** to the issue description. Once someone gets back to you to assist, please share the secret with that person privately.
+
+## Labeling secrets stored in 1Password
+
+With time the total amount of secrets stored in the vault will increase, therefore we need to label the secrets for better overview and grouping of the secrets. If you're adding a new secret to 1Password, please add a label depending on what this secret is related to. For example, if the secret is used by the Working Group, please use the respective Working Group label like ```wg-green-reviews``` or ```wg-comms```. Or ```SoMe``` for social media related secrets.
+
+See below sections for how access to the TAG ENV GitHub repository is managed and what is the process to contribute changes to the repository.
+
+## Github access permissions and administration
 
 The main GitHub repository for the TAG is `tag-env-sustainability`. TAG Leads have admin access to the repository and elected leads of working groups and projects maintain access which is defined in the [`cncf/people/config.yaml`](https://github.com/cncf/people/blob/main/config.yaml).
 
@@ -11,7 +25,7 @@ See [`cncf-tags`](https://github.com/cncf/toc/blob/main/tags/resources/cncf-tags
   - [Adding a commit to a TAG ENV repository](#adding-a-commit-to-a-tag-env-repository)
   - [GitHub project board](#github-project-board)
 
-## Adding a commit to a TAG ENV repository
+### Adding a commit to a TAG ENV repository
 
 Each contributor, including TAG leadership and CNCF personnel, does not commit directly to the `main` TAG ENV branch.
 To commit to the repository, create a branch off to the `main` branch, if you have maintain or admin privileges, or a [fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo) to the repository.
@@ -24,7 +38,7 @@ This highly limits the amount of branches and stops having branches around for l
 
 The [`CONTRIBUTING.md`](../CONTRIBUTING.md) gives more information about how to contribute to the TAG.
 
-## GitHub project board
+### GitHub project board
 
 The TAG uses a [project board](https://github.com/orgs/cncf/projects/10) to visualize and track issues.
 The project board has views for working groups or projects.


### PR DESCRIPTION
Renamed `github.md` to a more generic `access-management.md` naming to re-use the same document to store information related to access and secrets management. Added information about 1Password, how to add and request access to secrets, and how to label secrets for better overview and grouping.

Closes #336 