### PR TITLE
Add German translation for TAG Environmental Sustainability _index.md

### DIFF
--- a/website/content/de/_index.md
+++ b/website/content/de/_index.md
@@ -58,5 +58,4 @@ Fügen Sie den TAG ENV-Kalender-Feed von folgender URL in Ihren Kalender ein: [T
 - [Leonard Pahlke](https://github.com/leonardpahlke) (Chair)
 - [Marlow Weston](https://github.com/catblade) (Chair)
 - [Max Körbächer](https://github.com/mkorbi) (Chair)
-- [Cara Delia](https://github.com/caradelia) (TL)
 - [Kristina Devochko](https://github.com/guidemetothemoon) (TL)

--- a/website/content/de/_index.md
+++ b/website/content/de/_index.md
@@ -26,15 +26,15 @@ Alle wichtigen Links für die TAG Environmental Sustainability sind auch von ein
 - [TAG Charter](https://github.com/cncf/tag-env-sustainability/blob/main/charter.md)
 - [Events](https://tag-env-sustainability.cncf.io/events/)
 - Slack-Kanäle:
-  - [#tag-environmental-sustainability](https://cloud-native.slack.com/archives/C03F270PDU6)
-  - [#tag-env-wg-comms](https://cloud-native.slack.com/archives/C068XUD9AEA)
-  - [#tag-env-wg-green-reviews](https://cloud-native.slack.com/archives/C060EDHN431)
-  - [Invite yourself to the CNCF Slack](https://slack.cncf.io/)
+  - [#tag-umwelt-nachhaltigkeit](https://cloud-native.slack.com/archives/C03F270PDU6)
+  - [#tag-env-wg-Komms](https://cloud-native.slack.com/archives/C068XUD9AEA)
+  - [#tag-env-wg-green-bewertungen](https://cloud-native.slack.com/archives/C060EDHN431)
+  - [Laden Sie sich selbst zum CNCF Slack ein](https://slack.cncf.io/)
 - Social Media:
   - [LinkedIn](https://www.linkedin.com/company/cncf-tag-environmental-sustainability)
   - [Twitter/X](https://twitter.com/CNCFEnvTAG)
-- [Mailing list](https://lists.cncf.io/g/cncf-tag-env-sustainability/topics)
-- [Surveys](https://github.com/cncf/tag-env-sustainability/tree/main/artifacts/surveys)
+- [Mailingliste](https://lists.cncf.io/g/cncf-tag-env-sustainability/topics)
+- [Umfragen](https://github.com/cncf/tag-env-sustainability/tree/main/artifacts/surveys)
 
 ## Meetings
 

--- a/website/content/de/_index.md
+++ b/website/content/de/_index.md
@@ -16,11 +16,11 @@ toc_hide: true
 
 <p class="mt-5 mb-5"><img src="/images/tag-env-sustainability-header.webp" alt="TAG Environmental Sustainability"></p>
 
-Das Ziel dieser TAG ist es, Initiativen zur Umweltfreundlichen Nachhaltigkeit in Cloud Nativen Technologien zu befürworten, zu entwickeln, zu unterstützen und zu evaluieren. Diese TAG wird Werte und mögliche Anreize für Dienstleister identifizieren, um ihren Verbrauch und ihren CO2-Fußabdruck durch den Einsatz von Cloud Nativen Werkzeugen zu reduzieren.
+Das Ziel dieser TAG ist es, Initiativen zur Umweltfreundlichen Nachhaltigkeit in Cloud Nativen Technologien zu fördern, zu unterstützen und zu evaluieren. Diese TAG wird Werte und mögliche Anreize für Dienstleister identifizieren, um ihren Verbrauch und ihren CO2-Fußabdruck durch den Einsatz von Cloud Nativen Werkzeugen zu reduzieren.
 
 <!-- cSpell:ignore Linktree -->
 
-Alle wichtigen Links für die Umweltschutznachhaltigkeit von TAG sind auch von einer einzigen Linktree-Seite aus verfügbar: [cncfenvtag](https://linktr.ee/cncfenvtag).
+Alle wichtigen Links für die TAG Environmental Sustainability sind auch von einer einzigen Linktree-Seite aus verfügbar: [cncfenvtag](https://linktr.ee/cncfenvtag).
 
 - [GitHub Repository](https://github.com/cncf/tag-env-sustainability)
 - [TAG Charter](https://github.com/cncf/tag-env-sustainability/blob/main/charter.md)
@@ -30,18 +30,18 @@ Alle wichtigen Links für die Umweltschutznachhaltigkeit von TAG sind auch von e
   - [#tag-env-wg-comms](https://cloud-native.slack.com/archives/C068XUD9AEA)
   - [#tag-env-wg-green-reviews](https://cloud-native.slack.com/archives/C060EDHN431)
   - [Invite yourself to the CNCF Slack](https://slack.cncf.io/)
-- Social-Media-Konten:
+- Social Media:
   - [LinkedIn](https://www.linkedin.com/company/cncf-tag-environmental-sustainability)
   - [Twitter/X](https://twitter.com/CNCFEnvTAG)
 - [Mailing list](https://lists.cncf.io/g/cncf-tag-env-sustainability/topics)
 - [Surveys](https://github.com/cncf/tag-env-sustainability/tree/main/artifacts/surveys)
 
-## Treffen
+## Meetings
 
 1. und 3. Mittwoch jeden Monats um 16:00 UTC ([Konvertierung in Ihre lokale
    Zeitzone](https://dateful.com/convert/utc?t=16)).
 
-Die Treffen sind im [Hauptkalender des CNCF](https://www.cncf.io/calendar/)
+Die Meetings sind im [Hauptkalender des CNCF](https://www.cncf.io/calendar/)
 sowie im [TAG ENV-Kalender](https://calendar.google.com/calendar/embed?src=72e93a411f02e5664bb4485c04311b83dae6a62574e4ab882a1ccf8526aa9bf1%40group.calendar.google.com&ctz=America%2FChicago) aufgeführt.
 
 Sie können die Meeting-Reihe der Arbeitsgruppe zu Ihrem Kalender hinzufügen,
@@ -51,9 +51,9 @@ Fügen Sie den TAG ENV-Kalender-Feed von folgender URL in Ihren Kalender ein: [T
 
 - [Agenda und Notizen](https://bit.ly/cncf-tag-env-meeting-notes)
 - [Zoom-Meeting](https://zoom.us/my/cncftagenvsustainability) (Passwort: `77777`)
-- [Aufzeichnungen früherer Treffen](https://www.youtube.com/@CNCFEnvTAG/playlists) (Uploads erfolgen in Stapeln am Ende des Monats)
+- [Aufzeichnungen früherer Treffen](https://www.youtube.com/@CNCFEnvTAG/playlists) (Uploads erfolgen in gestaffelt am Ende des Monats)
 
-## Leiter
+## TAG Leitung
 
 - [Leonard Pahlke](https://github.com/leonardpahlke) (Chair)
 - [Marlow Weston](https://github.com/catblade) (Chair)

--- a/website/content/de/_index.md
+++ b/website/content/de/_index.md
@@ -16,7 +16,7 @@ toc_hide: true
 
 <p class="mt-5 mb-5"><img src="/images/tag-env-sustainability-header.webp" alt="TAG Environmental Sustainability"></p>
 
-Das Ziel dieser TAG ist es, Initiativen zur Umweltfreundlichen Nachhaltigkeit in Cloud-nativen Technologien zu befürworten, zu entwickeln, zu unterstützen und zu evaluieren. Diese TAG wird Werte und mögliche Anreize für Dienstleister identifizieren, um ihren Verbrauch und ihren CO2-Fußabdruck durch den Einsatz von Cloud-nativen Werkzeugen zu reduzieren.
+Das Ziel dieser TAG ist es, Initiativen zur Umweltfreundlichen Nachhaltigkeit in Cloud Nativen Technologien zu befürworten, zu entwickeln, zu unterstützen und zu evaluieren. Diese TAG wird Werte und mögliche Anreize für Dienstleister identifizieren, um ihren Verbrauch und ihren CO2-Fußabdruck durch den Einsatz von Cloud Nativen Werkzeugen zu reduzieren.
 
 <!-- cSpell:ignore Linktree -->
 

--- a/website/content/de/_index.md
+++ b/website/content/de/_index.md
@@ -1,0 +1,62 @@
+---
+title: TAG Environmental Sustainability
+toc_hide: true
+---
+
+<div class="row mt-5 mb-3">
+    <div class="col-lg-6">
+        <div class="lead">
+        TAG Environmental Sustainability unterstützt Projekte und Initiativen im Zusammenhang mit der Bereitstellung von Cloud-nativen Anwendungen, einschließlich deren Erstellung, Verpackung, Bereitstellung, Verwaltung und Betrieb.
+        </div>
+    </div>
+    <div class="col-lg-6">
+        <img src="/images/tag-environmental-sustainability_color.svg" alt="Tag Environmental Sustainability logo" style="max-width: 300px;">
+    </div>
+</div>
+
+<p class="mt-5 mb-5"><img src="/images/tag-env-sustainability-header.webp" alt="TAG Environmental Sustainability"></p>
+
+Das Ziel dieser TAG ist es, Initiativen zur Umweltfreundlichen Nachhaltigkeit in Cloud-nativen Technologien zu befürworten, zu entwickeln, zu unterstützen und zu evaluieren. Diese TAG wird Werte und mögliche Anreize für Dienstleister identifizieren, um ihren Verbrauch und ihren CO2-Fußabdruck durch den Einsatz von Cloud-nativen Werkzeugen zu reduzieren.
+
+<!-- cSpell:ignore Linktree -->
+
+Alle wichtigen Links für die Umweltschutznachhaltigkeit von TAG sind auch von einer einzigen Linktree-Seite aus verfügbar: [cncfenvtag](https://linktr.ee/cncfenvtag).
+
+- [GitHub Repository](https://github.com/cncf/tag-env-sustainability)
+- [TAG Charter](https://github.com/cncf/tag-env-sustainability/blob/main/charter.md)
+- [Events](https://tag-env-sustainability.cncf.io/events/)
+- Slack-Kanäle:
+  - [#tag-environmental-sustainability](https://cloud-native.slack.com/archives/C03F270PDU6)
+  - [#tag-env-wg-comms](https://cloud-native.slack.com/archives/C068XUD9AEA)
+  - [#tag-env-wg-green-reviews](https://cloud-native.slack.com/archives/C060EDHN431)
+  - [Invite yourself to the CNCF Slack](https://slack.cncf.io/)
+- Social-Media-Konten:
+  - [LinkedIn](https://www.linkedin.com/company/cncf-tag-environmental-sustainability)
+  - [Twitter/X](https://twitter.com/CNCFEnvTAG)
+- [Mailing list](https://lists.cncf.io/g/cncf-tag-env-sustainability/topics)
+- [Surveys](https://github.com/cncf/tag-env-sustainability/tree/main/artifacts/surveys)
+
+## Treffen
+
+1. und 3. Mittwoch jeden Monats um 16:00 UTC ([Konvertierung in Ihre lokale
+   Zeitzone](https://dateful.com/convert/utc?t=16)).
+
+Die Treffen sind im [Hauptkalender des CNCF](https://www.cncf.io/calendar/)
+sowie im [TAG ENV-Kalender](https://calendar.google.com/calendar/embed?src=72e93a411f02e5664bb4485c04311b83dae6a62574e4ab882a1ccf8526aa9bf1%40group.calendar.google.com&ctz=America%2FChicago) aufgeführt.
+
+Sie können die Meeting-Reihe der Arbeitsgruppe zu Ihrem Kalender hinzufügen,
+indem Sie den TAG ENV-Kalender-Feed zu Ihrem Kalender hinzufügen.
+
+Fügen Sie den TAG ENV-Kalender-Feed von folgender URL in Ihren Kalender ein: [TAG ENV-Kalender](https://calendar.google.com/calendar/embed?src=72e93a411f02e5664bb4485c04311b83dae6a62574e4ab882a1ccf8526aa9bf1%40group.calendar.google.com). Hier ist eine Anleitung, wie Sie dies in Google Kalender tun: [Abonnieren des Google Kalenders einer anderen Person](https://support.google.com/calendar/answer/37100?hl=en&co=GENIE.Platform%3DDesktop). In diesem Fall wird Ihr Kalender automatisch aktualisiert, sobald neue Veranstaltungen veröffentlicht werden.
+
+- [Agenda und Notizen](https://bit.ly/cncf-tag-env-meeting-notes)
+- [Zoom-Meeting](https://zoom.us/my/cncftagenvsustainability) (Passwort: `77777`)
+- [Aufzeichnungen früherer Treffen](https://www.youtube.com/@CNCFEnvTAG/playlists) (Uploads erfolgen in Stapeln am Ende des Monats)
+
+## Leiter
+
+- [Leonard Pahlke](https://github.com/leonardpahlke) (Chair)
+- [Marlow Weston](https://github.com/catblade) (Chair)
+- [Max Körbächer](https://github.com/mkorbi) (Chair)
+- [Cara Delia](https://github.com/caradelia) (TL)
+- [Kristina Devochko](https://github.com/guidemetothemoon) (TL)

--- a/website/content/de/_index.md
+++ b/website/content/de/_index.md
@@ -6,7 +6,7 @@ toc_hide: true
 <div class="row mt-5 mb-3">
     <div class="col-lg-6">
         <div class="lead">
-        TAG Environmental Sustainability unterstützt Projekte und Initiativen im Zusammenhang mit der Bereitstellung von Cloud-nativen Anwendungen, einschließlich deren Erstellung, Verpackung, Bereitstellung, Verwaltung und Betrieb.
+        TAG Environmental Sustainability unterstützt Projekte und Initiativen im Zusammenhang mit der Bereitstellung von Cloud Nativen Anwendungen, einschließlich deren Erstellung, Verpackung, Bereitstellung, Verwaltung und Betrieb.
         </div>
     </div>
     <div class="col-lg-6">


### PR DESCRIPTION
This commit adds the German translation for the TAG Environmental Sustainability landing page (_index.md) to the 'de' folder.