### PR TITLE
[ja] Localize some _index.md pages into Japanese

### DIFF
--- a/website/content/ja/about/_index.md
+++ b/website/content/ja/about/_index.md
@@ -1,0 +1,10 @@
+---
+title: TAG Environmental Sustainabilityについて
+linkTitle: About
+toc_hide: true
+list_pages: true
+menu:
+  main:
+    weight: 20
+description: TAG Environmental Sustainabilityによって運営されているWorking Groupとプロジェクトです。
+---

--- a/website/content/ja/about/_index.md
+++ b/website/content/ja/about/_index.md
@@ -1,6 +1,6 @@
 ---
 title: TAG Environmental Sustainabilityについて
-linkTitle: About
+linkTitle: TAG ENVについて
 toc_hide: true
 list_pages: true
 menu:

--- a/website/content/ja/about/projects.md
+++ b/website/content/ja/about/projects.md
@@ -1,0 +1,21 @@
+---
+title: プロジェクト
+description: このセクションでは、TAG Environmental Sustainabilityによって運営されているプロジェクトに関する情報を提供します。
+slug: projects
+---
+
+TAG Environmental Sustainabilityは、共通の目標や目的を達成するために協力し、調整するプロジェクトを展開しています。
+また、効率的な実行のためにメンバー間でタスクと責任を分担しています。
+成果物が達成された時点で完了する小規模なイニシアチブの場合、Working Groupを結成せず、プロジェクトとして実施されます。
+完了したプロジェクト、進行中のプロジェクト、あるいはキャンセルされたプロジェクトはすべてここにリストされています。
+各プロジェクトの詳細は[リポジトリ](https://github.com/cncf/tag-env-sustainability/tree/main/projects)で確認できます。
+
+以下のプロジェクトはTAG Environmental Sustainabilityによって運営されています:
+
+| **プロジェクト名** | **トラッキングIssue** | **プロジェクトリード** | **ステータス** | **開始** | **完了** |
+| :---: | :---: | :---: | :---: | :---: | :---: |
+| [クラウドネイティブの持続可能性への学習パス](https://github.com/cncf/tag-env-sustainability/tree/main/projects/2024-learning-path-sustainability) | [プロジェクトトラッキング](https://github.com/cncf/tag-env-sustainability/issues/52) | [@mkorbi](https://github.com/mkorbi) | 進行中 | 2024年2月 | 未定 |
+| [Landscapeの再構築(v2.0)](https://github.com/cncf/tag-env-sustainability/tree/main/projects/2024-landscape-rework-2) | [プロジェクトトラッキング](https://github.com/cncf/tag-env-sustainability/issues/302) | [@by-d-sign](https://github.com/by-d-sign), [@catblade](https://github.com/catblade) | 進行中 | 2024年2月 | 未定 |
+| [環境に優しいKubernetesクラスタのベストプラクティス](https://github.com/cncf/tag-env-sustainability/tree/main/projects/2024-best-practices-for-sustainable-k8s-clusters) | [プロジェクトトラッキング](https://github.com/cncf/tag-env-sustainability/issues/347) | [@JacobValdemar](https://github.com/JacobValdemar), [@xamebax](https://github.com/xamebax) | 進行中 | 2024年3月 | 未定 |
+| [Green Scraper - TAG ENVウェブサイトのための自動イベントリスト生成ツール](https://github.com/cncf/tag-env-sustainability/tree/main/projects/2024-green-scraper) | [プロジェクトトラッキング](https://github.com/cncf/tag-env-sustainability/issues/345) | [@guidemetothemoon](https://github.com/guidemetothemoon), [@Al-HusseinHameedJasim](https://github.com/Al-HusseinHameedJasim) | 進行中 | 2024年4月 | 未定 |
+| [Cloud Native Sustainability Week 2024](https://github.com/cncf/tag-env-sustainability/tree/main/projects/2024-cloud-native-sustainability-week-2024) | [プロジェクトトラッキング](https://github.com/cncf/tag-env-sustainability/issues/290) | [@nancy-chauhan](https://github.com/nancy-chauhan), [@juliechenadec](https://github.com/juliechenadec), [@ams0](https://github.com/ams0) | 進行中 | 2024年4月 | 未定 |

--- a/website/content/ja/about/working-groups.md
+++ b/website/content/ja/about/working-groups.md
@@ -1,0 +1,17 @@
+---
+title: Working Group
+description: このセクションでは、TAG Environmental Sustainabilityによって運営されるWorking Groupについての情報を提供します。
+slug: working-groups
+---
+
+TAG Environmental Sustainabilityには、共通の目標と目的を達成するために効果的に協力し調整するためのWorking Groupとチームがあります。
+また、コントリビューターの間でタスクと責任を分担することで、効率的な運営が可能となります。
+このアプローチにより、CNCFエコシステム内の複雑なプロジェクトをより整理された形で管理することができます。
+Working Groupの意図と、プロポーザルを提出するための全体のプロセスについては、Technical Oversight Committee(TOC)のGitHubで詳しく読むことができます: [CNCF Working Groups](https://github.com/cncf/toc/blob/main/workinggroups/README.md)。
+
+TAG Environmental Sustainabilityの下で運営されるWorking Groupは以下の通りです:
+
+| 名称 | スコープと目標 | ミーティングの時間 |
+| :---: | :---: | :---: |
+| [Green Reviews](https://github.com/cncf/tag-env-sustainability/tree/main/working-groups/green-reviews) | [Green Reviews Working Group Charter](https://github.com/cncf/tag-env-sustainability/tree/main/working-groups/green-reviews/charter.md) | [Green Reviews Working Group - ミーティングと連絡先](https://github.com/cncf/tag-env-sustainability/tree/main/working-groups/green-reviews/README.md#meetings-and-contact) |
+| [Communications](https://github.com/cncf/tag-env-sustainability/tree/main/working-groups/communications)| [Communications Working Group Charter](https://github.com/cncf/tag-env-sustainability/tree/main/working-groups/communications/charter.md) | [Communications Working Group - ミーティングと連絡先](https://github.com/cncf/tag-env-sustainability/blob/main/working-groups/communications/README.md#meetings-and-contact) |

--- a/website/content/ja/blog/_index.md
+++ b/website/content/ja/blog/_index.md
@@ -1,0 +1,9 @@
+---
+title: ブログ
+linkTitle: ブログ
+toc_hide: true
+list_pages: true
+menu:
+  main:
+    weight: 40
+---

--- a/website/content/ja/events/_index.md
+++ b/website/content/ja/events/_index.md
@@ -1,0 +1,9 @@
+---
+title: イベント
+linkTitle: イベント
+list_pages: true
+menu:
+  main:
+    weight: 30
+description: TAG Environmental Sustainabilityが参加するイベントです。
+---


### PR DESCRIPTION
tracking issue: #436

## Change List

Translate `/website/content/en`

- about/_index.md
- about/projects.md
- about/working-groups.md
- blog/_index.md
- events/_index.md

into Japanese