### PR TITLE
Fix deprecated errors in hugo

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -48,46 +48,63 @@ anchor = "smart"
 [languages]
 [languages.en]
 title = "CNCF TAG Environmental Sustainability"
-description = "TAG Environmental Sustainability focuses on enabling projects and initiatives related to delivering cloud-native applications, including building, deploying, managing, and operating them."
 languageName ="English"
 # Weight used for sorting.
 weight = 1
 contentDir = "content/en"
+
+[languages.en.params]
+description = "TAG Environmental Sustainability focuses on enabling projects and initiatives related to delivering cloud-native applications, including building, deploying, managing, and operating them."
+
 [languages.zh]
 title = "CNCF TAG Environmental Sustainability"
-description = "TAG环境可持续性专注于与交付云原生应用程序相关的扶持项目和举措，包括构建、部署、管理和运营这些应用程序。"
 languageName ="中文"
 # Weight used for sorting.
 weight = 2
 contentDir = "content/zh"
+
+[languages.zh.params]
+description = "TAG环境可持续性专注于与交付云原生应用程序相关的扶持项目和举措，包括构建、部署、管理和运营这些应用程序。"
+
 [languages.es]
 title = "CNCF TAG Environmental Sustainability"
-description = "TAG Sostenibilidad Ambiental se enfoca en habilitar proyectos e iniciativas para entregar aplicaciones cloud-native, incluyendo la construcción, despliegue, administración y las operaciones de las mismas."
 languageName ="Español"
 # Weight used for sorting.
 weight = 3
 contentDir = "content/es"
+
+[languages.es.params]
+description = "TAG Sostenibilidad Ambiental se enfoca en habilitar proyectos e iniciativas para entregar aplicaciones cloud-native, incluyendo la construcción, despliegue, administración y las operaciones de las mismas."
+
 [languages.de]
 title = "CNCF TAG Environmental Sustainability"
-description = "TAG Environmental Sustainability konzentriert sich auf die Unterstützung von Projekten und Initiativen im Zusammenhang mit der Bereitstellung von Cloud Nativen Anwendungen, einschließlich deren Entwicklung, Bereitstellung, Verwaltung und Betrieb."
 languageName ="Deutsch"
 # Weight used for sorting.
 weight = 4
 contentDir = "content/de"
+
+[languages.de.params]
+description = "TAG Environmental Sustainability konzentriert sich auf die Unterstützung von Projekten und Initiativen im Zusammenhang mit der Bereitstellung von Cloud Nativen Anwendungen, einschließlich deren Entwicklung, Bereitstellung, Verwaltung und Betrieb."
+
 [languages.ko]
 title = "CNCF TAG Environmental Sustainability"
-description = "TAG 환경 지속가능성은 클라우드 네이티브 애플케이션, 구축, 배포, 관리 그리고 운영을 위한 프로젝트와 이니셔티브를 중심으로 하고 있습니다."
 languageName ="Korean"
 # Weight used for sorting.
 weight = 5
 contentDir = "content/ko"
+
+[languages.ko.params]
+description = "TAG 환경 지속가능성은 클라우드 네이티브 애플케이션, 구축, 배포, 관리 그리고 운영을 위한 프로젝트와 이니셔티브를 중심으로 하고 있습니다."
+
 [languages.ja]
 title = "CNCF TAG Environmental Sustainability"
-description = "TAG Environmental Sustainabilityは、クラウドネイティブアプリケーションの構築、デプロイ、管理、運用を含むプロジェクトとイニシアチブの実現に焦点を当てています。"
 languageName ="日本語"
 # Weight used for sorting.
 weight = 6
 contentDir = "content/ja"
+
+[languages.ja.params]
+description = "TAG Environmental Sustainabilityは、クラウドネイティブアプリケーションの構築、デプロイ、管理、運用を含むプロジェクトとイニシアチブの実現に焦点を当てています。"
 
 [markup]
   [markup.goldmark]


### PR DESCRIPTION
## Change List

- Fix deprecated errors
    - create new fields (`[languages.:lang.params]` to resolve)

> ERROR deprecated: config: languages.en.description: custom params on the language top level was deprecated in Hugo v0.112.0 and will be removed in Hugo 0.128.0. Put the value below [languages.en.params]. See https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120
> ...

