### PR TITLE
Add issue template for local meetup organisers

### DIFF
--- a/.github/ISSUE_TEMPLATE/10-action copy.yml
+++ b/.github/ISSUE_TEMPLATE/10-action copy.yml
@@ -1,0 +1,62 @@
+name: Local Meetup Tracking/Action Item
+description: Use this issue type to track and manage local meetup organization tasks. Avoid using this issue type for tasks expected to be closed within hours.
+title: "[<Tracking>/<Action>] Cloud Native Sustainability Week 2024 <Meetup Location>"
+labels: ["issue/needs-triage", "board/unassigned"]
+projects: ["cncf/10"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for contributing to the TAG!
+        Please remember that an issue is not the place to ask questions.
+        For inquiries, please refer to the README on how to reach us: [Contact](https://github.com/cncf/tag-env-sustainability#contact).
+        Thank you! :)
+  - id: description
+    type: textarea
+    attributes:
+      label: Description
+      description: |
+        Please provide the following details:
+        * **Location/Region:**
+        * **Organizers:**
+        * **Sponsors:**
+        * **Date:**
+        * **Event link:**
+    validations:
+      required: true
+  - id: details
+    type: textarea
+    attributes:
+      label: Details
+      description: What are the goals and activities planned for the meetup?
+    validations:
+      required: true
+  - id: todo
+    type: textarea
+    attributes:
+      label: To-Do
+      description: What specific actions are needed to organize this meetup?
+      value: |
+        1. [Local organizer] Review the [Meetup Organizer Guide](https://docs.google.com/document/d/1xfUqxt0EeMhrsg8h5p_cAJ1ZHzWryrIywue53rVRFJw/edit?usp=sharing) for onboarding.
+        2. [Local organizer] Check the [website](https://tag-env-sustainability.cncf.io/events/cloud-native-sustainability-week/).
+        3. [Local organizer] Create a PR to update the Meetup's table on the [website](https://tag-env-sustainability.cncf.io/events/cloud-native-sustainability-week/). Example [PR](https://github.com/cncf/tag-env-sustainability/pull/170).
+        4. [TAG ENV Lead] Assign lead organizer/co-lead to the issue.
+        5. Tag leads & co-leads if assistance is needed.
+    validations:
+        required: false
+  - id: coc
+    type: checkboxes
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://www.cncf.io/conduct/).
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true
+  - id: comments
+    type: textarea
+    attributes:
+      label: Comments
+      description: Additional comments or details.
+      placeholder: None
+    validations:
+        required: false

--- a/.github/ISSUE_TEMPLATE/10-local-meetup.yml
+++ b/.github/ISSUE_TEMPLATE/10-local-meetup.yml
@@ -1,6 +1,6 @@
 name: Local Meetup Tracking/Action Item
 description: Use this issue type to track and manage local meetup organization tasks. Avoid using this issue type for tasks expected to be closed within hours.
-title: "[<Tracking>/<Action>] Cloud Native Sustainability Week 2024 <Meetup Location>"
+title: "[<Tracking>] Cloud Native Sustainability Week <Year> <Meetup Location>"
 labels: ["issue/needs-triage", "board/unassigned"]
 projects: ["cncf/10"]
 body:
@@ -32,18 +32,29 @@ body:
     validations:
       required: true
   - id: todo
-    type: textarea
+    type: checkboxes
     attributes:
       label: To-Do
-      description: What specific actions are needed to organize this meetup?
-      value: |
-        1. [Local organizer] Review the [Meetup Organizer Guide](https://docs.google.com/document/d/1xfUqxt0EeMhrsg8h5p_cAJ1ZHzWryrIywue53rVRFJw/edit?usp=sharing) for onboarding.
-        2. [Local organizer] Check the [website](https://tag-env-sustainability.cncf.io/events/cloud-native-sustainability-week/).
-        3. [Local organizer] Create a PR to update the Meetup's table on the [website](https://tag-env-sustainability.cncf.io/events/cloud-native-sustainability-week/). Example [PR](https://github.com/cncf/tag-env-sustainability/pull/170).
-        4. [TAG ENV Lead] Assign lead organizer/co-lead to the issue.
-        5. Tag leads & co-leads if assistance is needed.
-    validations:
-        required: false
+      description: What specific actions are needed to organize this meetup?      
+      options:
+        - label: Review the [Meetup Organizer Guide](https://docs.google.com/document/d/1xfUqxt0EeMhrsg8h5p_cAJ1ZHzWryrIywue53rVRFJw/edit?usp=sharing) for onboarding.
+          required: true
+        - label: Check the [website](https://tag-env-sustainability.cncf.io/events/cloud-native-sustainability-week/).
+          required: true
+        - label: Create a PR to update the Meetup's table on the [website](https://tag-env-sustainability.cncf.io/events/cloud-native-sustainability-week/). Example [PR](https://github.com/cncf/tag-env-sustainability/pull/170).
+          required: true     
+        - label: Join one of the TAG ENV Sustainability Week Syncs to talk about your event.
+          required: true 
+        - label: Find a sponsor for the event.
+          required: true   
+        - label: Find a location for the event.
+          required: true
+        - label: Set a date for the event.
+          required: true
+        - label: Announce the event.
+          required: true
+        - label: Reach out to the Cloud Native Sustainability Week Organizer team to promote the event.
+          required: true
   - id: coc
     type: checkboxes
     attributes:


### PR DESCRIPTION
This PR updates the issue template for tracking and managing local meetup organization tasks. The new template aims to provide a clear and structured way for organizers to detail their event plans, ensuring all necessary information is included and that the process is streamlined.