### PR TITLE
Sorting the display order of languages

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -56,11 +56,41 @@ contentDir = "content/en"
 [languages.en.params]
 description = "TAG Environmental Sustainability focuses on enabling projects and initiatives related to delivering cloud-native applications, including building, deploying, managing, and operating them."
 
+[languages.de]
+title = "CNCF TAG Environmental Sustainability"
+languageName ="Deutsch (German)"
+# Weight used for sorting.
+weight = 2
+contentDir = "content/de"
+
+[languages.de.params]
+description = "TAG Environmental Sustainability konzentriert sich auf die Unterstützung von Projekten und Initiativen im Zusammenhang mit der Bereitstellung von Cloud Nativen Anwendungen, einschließlich deren Entwicklung, Bereitstellung, Verwaltung und Betrieb."
+
+[languages.ja]
+title = "CNCF TAG Environmental Sustainability"
+languageName ="日本語 (Japanese)"
+# Weight used for sorting.
+weight = 3
+contentDir = "content/ja"
+
+[languages.ja.params]
+description = "TAG Environmental Sustainabilityは、クラウドネイティブアプリケーションの構築、デプロイ、管理、運用を含むプロジェクトとイニシアチブの実現に焦点を当てています。"
+
+[languages.ko]
+title = "CNCF TAG Environmental Sustainability"
+languageName ="한국어 (Korean)"
+# Weight used for sorting.
+weight = 4
+contentDir = "content/ko"
+
+[languages.ko.params]
+description = "TAG 환경 지속가능성은 클라우드 네이티브 애플케이션, 구축, 배포, 관리 그리고 운영을 위한 프로젝트와 이니셔티브를 중심으로 하고 있습니다."
+
 [languages.zh]
 title = "CNCF TAG Environmental Sustainability"
 languageName ="简体中文 (Simplified Chinese)"
 # Weight used for sorting.
-weight = 2
+weight = 5
 contentDir = "content/zh"
 
 [languages.zh.params]
@@ -70,41 +100,11 @@ description = "TAG环境可持续性专注于与交付云原生应用程序相�
 title = "CNCF TAG Environmental Sustainability"
 languageName ="Español (Spanish)"
 # Weight used for sorting.
-weight = 3
+weight = 6
 contentDir = "content/es"
 
 [languages.es.params]
 description = "TAG Sostenibilidad Ambiental se enfoca en habilitar proyectos e iniciativas para entregar aplicaciones cloud-native, incluyendo la construcción, despliegue, administración y las operaciones de las mismas."
-
-[languages.de]
-title = "CNCF TAG Environmental Sustainability"
-languageName ="Deutsch (German)"
-# Weight used for sorting.
-weight = 4
-contentDir = "content/de"
-
-[languages.de.params]
-description = "TAG Environmental Sustainability konzentriert sich auf die Unterstützung von Projekten und Initiativen im Zusammenhang mit der Bereitstellung von Cloud Nativen Anwendungen, einschließlich deren Entwicklung, Bereitstellung, Verwaltung und Betrieb."
-
-[languages.ko]
-title = "CNCF TAG Environmental Sustainability"
-languageName ="한국어 (Korean)"
-# Weight used for sorting.
-weight = 5
-contentDir = "content/ko"
-
-[languages.ko.params]
-description = "TAG 환경 지속가능성은 클라우드 네이티브 애플케이션, 구축, 배포, 관리 그리고 운영을 위한 프로젝트와 이니셔티브를 중심으로 하고 있습니다."
-
-[languages.ja]
-title = "CNCF TAG Environmental Sustainability"
-languageName ="日本語 (Japanese)"
-# Weight used for sorting.
-weight = 6
-contentDir = "content/ja"
-
-[languages.ja.params]
-description = "TAG Environmental Sustainabilityは、クラウドネイティブアプリケーションの構築、デプロイ、管理、運用を含むプロジェクトとイニシアチブの実現に焦点を当てています。"
 
 [markup]
   [markup.goldmark]

--- a/website/config.toml
+++ b/website/config.toml
@@ -58,7 +58,7 @@ description = "TAG Environmental Sustainability focuses on enabling projects and
 
 [languages.zh]
 title = "CNCF TAG Environmental Sustainability"
-languageName ="中文"
+languageName ="简体中文 (Simplified Chinese)"
 # Weight used for sorting.
 weight = 2
 contentDir = "content/zh"
@@ -68,7 +68,7 @@ description = "TAG环境可持续性专注于与交付云原生应用程序相�
 
 [languages.es]
 title = "CNCF TAG Environmental Sustainability"
-languageName ="Español"
+languageName ="Español (Spanish)"
 # Weight used for sorting.
 weight = 3
 contentDir = "content/es"
@@ -78,7 +78,7 @@ description = "TAG Sostenibilidad Ambiental se enfoca en habilitar proyectos e i
 
 [languages.de]
 title = "CNCF TAG Environmental Sustainability"
-languageName ="Deutsch"
+languageName ="Deutsch (German)"
 # Weight used for sorting.
 weight = 4
 contentDir = "content/de"
@@ -88,7 +88,7 @@ description = "TAG Environmental Sustainability konzentriert sich auf die Unters
 
 [languages.ko]
 title = "CNCF TAG Environmental Sustainability"
-languageName ="Korean"
+languageName ="한국어 (Korean)"
 # Weight used for sorting.
 weight = 5
 contentDir = "content/ko"
@@ -98,7 +98,7 @@ description = "TAG 환경 지속가능성은 클라우드 네이티브 애플케
 
 [languages.ja]
 title = "CNCF TAG Environmental Sustainability"
-languageName ="日本語"
+languageName ="日本語 (Japanese)"
 # Weight used for sorting.
 weight = 6
 contentDir = "content/ja"


### PR DESCRIPTION
## Background

On the TAG ENV website, there was no specific order for displaying languages, and the notations were inconsistent. As shown in the image, Chinese was written as "中文" (in the local language), while Korean was written as "Korean" in English.

<img width="1512" alt="Screenshot 2024-07-03 at 22 58 19" src="https://github.com/cncf/tag-env-sustainability/assets/86868255/46aacf8f-3fc0-43cb-8741-b1137dba0f7d">

## Change List

- Change all languages to `Local Language (English notation)`
- Sort the weight to be in alphabetical order based on the English notation

_This is the same method used by CNCF/Glossary. Please note that CNCF/Glossary is one of the most advanced projects regarding localization_