### PR TITLE
update cloud native sustainability week issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/10-local-meetup.yml
+++ b/.github/ISSUE_TEMPLATE/10-local-meetup.yml
@@ -1,7 +1,7 @@
-name: Local Meetup Tracking/Action Item
+name: Cloud Native Sustainability Week Local Meetup Tracking Issue
 description: Use this issue type to track and manage local meetup organization tasks. Avoid using this issue type for tasks expected to be closed within hours.
-title: "[<Tracking>] Cloud Native Sustainability Week <Year> <Meetup Location>"
-labels: ["issue/needs-triage", "board/unassigned"]
+title: "[Tracking] Cloud Native Sustainability Week <Year> <Meetup Location>"
+labels: ["issue/needs-triage", "project/cloud-native-sustainability-week"]
 projects: ["cncf/10"]
 body:
   - type: markdown
@@ -16,12 +16,13 @@ body:
     attributes:
       label: Description
       description: |
-        Please provide the following details:
-        * **Location/Region:**
-        * **Organizers:**
-        * **Sponsors:**
-        * **Date:**
-        * **Event link:**
+        Please update these details along the way.  
+      value: |
+        * **Location/Region:** tbd
+        * **Organizers:** tbd
+        * **Sponsors:** tbd
+        * **Date:** tbd
+        * **Event link:** tbd
     validations:
       required: true
   - id: details
@@ -42,19 +43,19 @@ body:
         - label: Check the [website](https://tag-env-sustainability.cncf.io/events/cloud-native-sustainability-week/).
           required: true
         - label: Create a PR to update the Meetup's table on the [website](https://tag-env-sustainability.cncf.io/events/cloud-native-sustainability-week/). Example [PR](https://github.com/cncf/tag-env-sustainability/pull/170).
-          required: true     
+          required: false     
         - label: Join one of the TAG ENV Sustainability Week Syncs to talk about your event.
-          required: true 
+          required: false 
         - label: Find a sponsor for the event.
-          required: true   
+          required: false   
         - label: Find a location for the event.
-          required: true
+          required: false
         - label: Set a date for the event.
-          required: true
+          required: false
         - label: Announce the event.
-          required: true
+          required: false
         - label: Reach out to the Cloud Native Sustainability Week Organizer team to promote the event.
-          required: true
+          required: false
   - id: coc
     type: checkboxes
     attributes:


### PR DESCRIPTION
Update some parts of the cloud native sustainability week. 

Not all items of the checklist are required, since not all tasks will be done at the time of creating the issue. 

- see https://github.com/cncf/tag-env-sustainability/pull/446