### PR TITLE
Add Aarhus, Denmark to the Cloud Native Sustainability Week 2024

### DIFF
--- a/website/content/en/events/2024-cloud-native-sustainability-week.md
+++ b/website/content/en/events/2024-cloud-native-sustainability-week.md
@@ -36,6 +36,7 @@ After the successful [Sustainability Week 2023](https://tag-env-sustainability.c
 | 6 | Milan, Italy | TBD | TBD |  Michel Murabito
 | 7 | Sao Paulo, Brazil | TBD | TBD | Carol Valenica
 | 8 | India | TBD | TBD | Saiyam
+| 9 | Aarhus, Denmark | October 7th | TBD | [Cloud Native Aarhus Organizers](https://community.cncf.io/aarhus/)
 <!-- cSpell:enable -->
 
 ## Event Goals


### PR DESCRIPTION
This adds Aarhus, Denmark to the list of Cloud Native Sustainability Week 2024 events on the website.