### PR TITLE
Add link to CNCF Sustainability Week in Aarhus event

### DIFF
--- a/website/content/en/events/2024-cloud-native-sustainability-week.md
+++ b/website/content/en/events/2024-cloud-native-sustainability-week.md
@@ -36,7 +36,7 @@ After the successful [Sustainability Week 2023](https://tag-env-sustainability.c
 | 6 | Milan, Italy | TBD | TBD |  Michel Murabito, Valeria Salis, Ludovica Bonaldo
 | 7 | Sao Paulo, Brazil | TBD | TBD | Carol Valenica
 | 8 | India | TBD | TBD | Saiyam
-| 9 | Aarhus, Denmark | October 7th | TBD | [Cloud Native Aarhus Organizers](https://community.cncf.io/aarhus/)
+| 9 | Aarhus, Denmark | October 7th | [Link](https://community.cncf.io/events/details/cncf-aarhus-presents-cncf-sustainability-week-aarhus-2024/) | [Cloud Native Aarhus Organizers](https://community.cncf.io/aarhus/)
 | 10 | Kuala Lumpur, Malaysia | Oct. 22 | TBD | Mageshwaran Sekar, Khairul Anuar, Ahmed Zidan
 | 11 | Stuttgart, Germany | TBD| TBD | Danijel Soldo, Stefan Bergstein
 <!-- cSpell:enable -->


### PR DESCRIPTION
This updates the CNCF Sustainability Week event in Aarhus with the published event link. 