### PR TITLE
docs: Adds event link for Oslo Cloud Native Sustainability Week 2024

### DIFF
--- a/website/content/en/events/2024-cloud-native-sustainability-week.md
+++ b/website/content/en/events/2024-cloud-native-sustainability-week.md
@@ -31,7 +31,7 @@ After the successful [Sustainability Week 2023](https://tag-env-sustainability.c
 | 1 | Amsterdam, Netherlands | 10th October | [link](https://community.cncf.io/e/mwszqh/) | Julie Chenadec, Alessandro Vozza, Pavel Chunyayev, Matteo Bianchi
 | 2 | Guatemala | TBD | TBD | Sergio Méndez
 | 3 | China | TBD | TBD | Sam Yuan
-| 4 | Oslo, Norway | Oct. 9 | TBD | Marta Paciorkowska, Kristina Devochko, [Green Software - Oslo](https://www.meetup.com/gsf-oslo)
+| 4 | Oslo, Norway | Oct. 9 | [Link](https://www.meetup.com/gsf-oslo/events/303318869/) | Marta Paciorkowska, Kristina Devochko, [Green Software - Oslo](https://www.meetup.com/gsf-oslo)
 | 5 | Tokyo, Japan | Oct. 4 | [Link](https://community.cncf.io/events/details/cncf-cloud-native-community-japan-presents-cncf-cloud-native-sustainability-week-2024-local-meetup-tokyo/) | Sunyanan Choochotkeaw ([Cloud Native Community Japan](https://community.cncf.io/cloud-native-community-japan/))
 | 6 | Milan, Italy | TBD | TBD |  Michel Murabito, Valeria Salis, Ludovica Bonaldo
 | 7 | Sao Paulo, Brazil | TBD | TBD | Carol Valencia, Tiago Reichert

--- a/website/content/es/events/2024-cloud-native-sustainability-week.md
+++ b/website/content/es/events/2024-cloud-native-sustainability-week.md
@@ -31,7 +31,7 @@ After the successful [Sustainability Week 2023](https://tag-env-sustainability.c
 | 1 | Amsterdam, Netherlands | TBD | TBD | Brendan Kamp
 | 2 | Guatemala | TBD | TBD | Sergio Méndez
 | 3 | China | TBD | TBD | Sam Yuan
-| 4 | Oslo, Norway | Oct.9 | TBD | Marta Paciorkowska, Kristina Devochko, [Green Software - Oslo](https://www.meetup.com/gsf-oslo)
+| 4 | Oslo, Norway | Oct.9 | [Link](https://www.meetup.com/gsf-oslo/events/303318869/) | Marta Paciorkowska, Kristina Devochko, [Green Software - Oslo](https://www.meetup.com/gsf-oslo)
 | 5 | Tokyo, Japan | Oct.4 | [Link](https://community.cncf.io/events/details/cncf-cloud-native-community-japan-presents-cncf-cloud-native-sustainability-week-2024-local-meetup-tokyo/) | Sunyanan Choochotkeaw ([Cloud Native Community Japan](https://community.cncf.io/cloud-native-community-japan/))
 | 6 | Milan, Italy | TBD | TBD |  Michel Murabito
 | 7 | Sao Paulo, Brazil | TBD | TBD | Carol Valencia, Tiago Reichert

--- a/website/content/ja/events/2024-cloud-native-sustainability-week.md
+++ b/website/content/ja/events/2024-cloud-native-sustainability-week.md
@@ -31,7 +31,7 @@ CNCFサステナビリティ週間は、[環境持続可能性のためのCNCF T
 | 1 | Amsterdam, Netherlands | TBD | TBD | Brendan Kamp
 | 2 | Guatemala | TBD | TBD | Sergio Méndez
 | 3 | China | TBD | TBD | Sam Yuan
-| 4 | Oslo, Norway | Oct.9 | TBD | Marta Paciorkowska, Kristina Devochko, [Green Software - Oslo](https://www.meetup.com/gsf-oslo)
+| 4 | Oslo, Norway | Oct.9 | [Link](https://www.meetup.com/gsf-oslo/events/303318869/) | Marta Paciorkowska, Kristina Devochko, [Green Software - Oslo](https://www.meetup.com/gsf-oslo)
 | 5 | Tokyo, Japan | Oct.4 | [Link](https://community.cncf.io/events/details/cncf-cloud-native-community-japan-presents-cncf-cloud-native-sustainability-week-2024-local-meetup-tokyo/) | Sunyanan Choochotkeaw ([Cloud Native Community Japan](https://community.cncf.io/cloud-native-community-japan/))
 | 6 | Milan, Italy | TBD | TBD |  Michel Murabito
 | 7 | Sao Paulo, Brazil | TBD | TBD | Carol Valencia, Tiago Reichert

--- a/website/content/ko/events/2024-cloud-native-sustainability-week.md
+++ b/website/content/ko/events/2024-cloud-native-sustainability-week.md
@@ -31,7 +31,7 @@ After the successful [Sustainability Week 2023](https://tag-env-sustainability.c
 | 1 | Amsterdam, Netherlands | TBD | TBD | Brendan Kamp
 | 2 | Guatemala | TBD | TBD | Sergio Méndez
 | 3 | China | TBD | TBD | Sam Yuan
-| 4 | Oslo, Norway | Oct.9 | TBD | Marta Paciorkowska, Kristina Devochko, [Green Software - Oslo](https://www.meetup.com/gsf-oslo)
+| 4 | Oslo, Norway | Oct.9 | [Link](https://www.meetup.com/gsf-oslo/events/303318869/) | Marta Paciorkowska, Kristina Devochko, [Green Software - Oslo](https://www.meetup.com/gsf-oslo)
 | 5 | Tokyo, Japan | Oct.4 | [Link](https://community.cncf.io/events/details/cncf-cloud-native-community-japan-presents-cncf-cloud-native-sustainability-week-2024-local-meetup-tokyo/) | Sunyanan Choochotkeaw ([Cloud Native Community Japan](https://community.cncf.io/cloud-native-community-japan/))
 | 6 | Milan, Italy | TBD | TBD |  Michel Murabito
 | 7 | Sao Paulo, Brazil | TBD | TBD | Carol Valencia, Tiago Reichert

--- a/website/content/zh/events/2024-cloud-native-sustainability-week.md
+++ b/website/content/zh/events/2024-cloud-native-sustainability-week.md
@@ -33,7 +33,7 @@ CNCF可持续发展周是由[CNCF环境可持续性技术咨询小组（TAG ENV�
 | 1 | Amsterdam, Netherlands | TBD | TBD | Brendan Kamp
 | 2 | Guatemala | TBD | TBD | Sergio Méndez
 | 3 | China | TBD | TBD | Sam Yuan
-| 4 | Oslo, Norway | Oct.9 | TBD | Marta Paciorkowska, Kristina Devochko, [Green Software - Oslo](https://www.meetup.com/gsf-oslo)
+| 4 | Oslo, Norway | Oct.9 | [Link](https://www.meetup.com/gsf-oslo/events/303318869/) | Marta Paciorkowska, Kristina Devochko, [Green Software - Oslo](https://www.meetup.com/gsf-oslo)
 | 5 | Tokyo, Japan | Oct.4 | [Link](https://community.cncf.io/events/details/cncf-cloud-native-community-japan-presents-cncf-cloud-native-sustainability-week-2024-local-meetup-tokyo/) | Sunyanan Choochotkeaw ([Cloud Native Community Japan](https://community.cncf.io/cloud-native-community-japan/))
 | 6 | Milan, Italy | TBD | TBD |  Michel Murabito
 | 7 | Sao Paulo, Brazil | TBD | TBD | Carol Valencia, Tiago Reichert


### PR DESCRIPTION
Update information for Cloud Native Sustainability Week 2024 event that will take place in Oslo, Norway in October.
Ref. https://github.com/cncf/tag-env-sustainability/issues/487