### PR TITLE
Add Flavia as TL of Green Reviews WG 

### DIFF
--- a/working-groups/green-reviews/README.md
+++ b/working-groups/green-reviews/README.md
@@ -21,6 +21,7 @@ The working group currently has 2 chairs serving a term of 6 months and as long 
 
 <!-- cSpell:disable -->
 - Ross Fairbanks, [@rossf7](https://github.com/rossf7), serving as TL since 14.12.2023
+- Flavia Paganelli, [@locomundo](https://github.com/locomundo), serving as TL since 1.10.2024
 <!-- cSpell:enable -->
 
 ## Meetings and Contact


### PR DESCRIPTION
Adding @locomundo who is now a TL for the Green Reviews WG https://github.com/cncf/tag-env-sustainability/issues/513 🎉 