### PR TITLE
Add event page for KCCN NA 2024

### DIFF
--- a/website/content/en/events/2024-kubecon-na.md
+++ b/website/content/en/events/2024-kubecon-na.md
@@ -1,0 +1,40 @@
+---
+title: Kubecon + CloudNativeCon NA 2024
+description: TAG Environmental Sustainability presence at Cloud Native Computing Foundation’s flagship conference in Salt Lake City, Utah from 12-15 November, 2024.
+weight: 93
+---
+
+The Cloud Native Computing Foundation’s flagship conference gathers adopters and technologists from leading open source and cloud native communities in Salt Lake City, Utah from 12-15 November, 2024.
+
+The TAG will also be running a few things in Paris!
+
+## TAG Booth
+
+TAG members will be at our booth on the AM of Wednesday, Thursday, and Friday! Find us at <TBA>! Come and chat to us about the work we are currently doing, different projects and working groups, or how you can get involved!
+
+
+## TAG [Talk](https://sched.co/1hovS)
+
+The carbon must be counted. In the Environmental Sustainability TAG, we focus on current and emerging technologies regarding carbon measurement and minimization. As our digital landscape grows, so does its impact on the environment—a factor often overlooked in the pursuit of technological advancement, such as AI. Traditionally, companies focused primarily on financial metrics. However, with increasing awareness of climate issues, stricter regulations, and rising energy costs, environmental impact is now a crucial consideration. We highlight the Green Reviews Working Group and our project to measure impact. We're developing a pipeline that works with current tooling, such as Kepler, to measure the power consumption of CNCF Projects. We explore how to measure energy consumption and emissions of software projects. We also give the status of other projects, such as the sustainability landscape, initiatives such as our sustainability week, and collaborative organisations.
+
+## Sustainability related talks at a glance
+
+### Tuesday 12th of November
+
+10:06am - 10:11am MST
+
+* [Kepler: How's Things Going in Kepler? | Project Lightning Talk](https://sched.co/1iW8V)
+
+### Wednesday 13th of November
+
+11:15am - 11:50am MST
+
+* [The Spice Must Flow Green: CNCF's Environmental Sustainability TAG](https://sched.co/1hovS) ⬅️ brought to you by the TAG ENV
+
+14:30pm - 15:05pm MST
+
+* [Cloud Native Sustainability Speedrun: Tools from Infrastructure to Application Level](https://sched.co/1i7lW)
+
+18:00pm - 20:00pm MST
+
+* [🪧 Poster Session (PS01): Climatik: Cloud Native Sustainable LLM via Power Capping](https://sched.co/1i7mv)


### PR DESCRIPTION
Add event page with TAG ENV activities and sustainability-related talks for KubeCon + CloudNativeCon North America 2024 to the TAG ENV website.
Related to #509 