### PR TITLE
Remove changed-files action which was compromised

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -11,22 +11,17 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    
-    - uses: tj-actions/changed-files@v39
-      id: changed-files
-      with:
-        files: '**/*.md'
-        separator: ','
 
-    - name: Lint Markdown files
-      uses: DavidAnson/markdownlint-cli2-action@v13.0.0
-      if: steps.changed-files.outputs.any_changed == 'true'
-      with:
-        globs: ${{ steps.changed-files.outputs.all_changed_files }}
-        separator: ','
-        config: '.markdownlint.json' 
-        fix: true
-      continue-on-error: false
+    # ToDo - Look into different way to perform markdown linting if this will still be relevant
+    #- name: Lint Markdown files
+    #  uses: DavidAnson/markdownlint-cli2-action@v13.0.0
+    #  if: steps.changed-files.outputs.any_changed == 'true'
+    #  with:
+    #    globs: ${{ steps.changed-files.outputs.all_changed_files }}
+    #    separator: ','
+    #    config: '.markdownlint.json' 
+    #    fix: true
+    #  continue-on-error: false
     
     - name: Install Node
       uses: actions/setup-node@v3


### PR DESCRIPTION
Remove changed-files action which was compromised, see more about the vulnerability here: https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised
Workflow has been disabled for now, we can re-evaluate if we need to make any further work on it since it may not be applicable anymore due to upcoming restructuring. Ref. #589 