### PR TITLE
Add missing talk to KCCN EU 25 event page

### DIFF
--- a/website/content/en/events/2025-kubecon-eu.md
+++ b/website/content/en/events/2025-kubecon-eu.md
@@ -6,7 +6,6 @@ weight: 92
 
 The Cloud Native Computing Foundation’s flagship conference gathers adopters and technologists from leading open source and cloud native communities in London, UK from 1-4 April 2025.
 
-
 ## TAG Booth
 
 TAG members will be at our booth on the AM of Wednesday, Thursday, and Friday! Find us at: Level 1 | Hall Entrance N8 - N9 | Project Pavilion. Come and chat to us about the work we are currently doing, different projects and working groups, or how you can get involved!
@@ -15,7 +14,6 @@ TAG members will be at our booth on the AM of Wednesday, Thursday, and Friday! F
 
 We're hosting an informal meetup for everyone who's interested in the TAG ENV, more details to follow!
 
-
 ## Sustainability related talks at a glance
 
 ### Tuesday 1st of April
@@ -23,7 +21,6 @@ We're hosting an informal meetup for everyone who's interested in the TAG ENV, m
 14:43:30 - 14:48 (Platinum Suite | Level 3)
 
 * [Project Lightning Talk: Kepler Project Updates - Sunyanan Choochotkaew, Maintainer](https://kccnceu2025.sched.com/event/1tcwI)
-
 
 ### Wednesday 2nd of April
 
@@ -47,6 +44,9 @@ We're hosting an informal meetup for everyone who's interested in the TAG ENV, m
 
 * [Kubernetes Meets Climate Science: Building Large-scale Feature Detection From Climate Data Records - Armagan Karatosun & Roope Tervo, European Organisation for the Exploitation of Meteorological Satellites](https://kccnceu2025.sched.com/event/1txAZ)
 
+13:45 - 14:15 (Level 0 | ICC Capital Hall | Room J)
+
+* [Kubernetes and AI To Protect Our Forests: A Cloud Native Infrastructure for Wildfire Prevention - Andrea Giardini, Cloud Native Consultant / Trainer, Crossover Engineering](https://sched.co/1txAW)
 
 15:15 - 15:45 (Level 1 | Hall Entrance S10 | Room A)
 


### PR DESCRIPTION
Add missing talk to KubeCon + CloudNativeCon EU 2025 event page on the TAG ENV website + update linting errors.
Related to #571 